### PR TITLE
Handle `base_resolution` for mesh size fields

### DIFF
--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -212,7 +212,7 @@ class Model:
 
             # Assemble with other shapes
             base_resolution = (
-                resolutions[label]["resolution"]
+                resolutions[label].get("resolution", default_characteristic_length)
                 if label in resolutions
                 else default_characteristic_length
             )


### PR DESCRIPTION
Don't assume a `resolutions` key

Closes #23 