### PR TITLE
Refactoring API

### DIFF
--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -13,6 +13,7 @@ class GMSH_entity:
         model: meshwell model
         physical_name: name of the physical this entity wil belong to
         mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
+        mesh_bool: if True, entity will be meshed; if not, will not be meshed (useful to tag boundaries)
     """
 
     def __init__(
@@ -21,8 +22,9 @@ class GMSH_entity:
         gmsh_function_kwargs,
         dim,
         model,
-        physical_name,
+        physical_name=None,
         mesh_order=np.inf,
+        mesh_bool=True,
     ):
         self.gmsh_function = gmsh_function
         self.gmsh_function_kwargs = gmsh_function_kwargs
@@ -30,6 +32,7 @@ class GMSH_entity:
         self.model = model
         self.mesh_order = mesh_order
         self.physical_name = physical_name
+        self.mesh_bool = mesh_bool
 
     def instanciate(self):
         """Returns dim tag from entity."""

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -1,4 +1,5 @@
 import gmsh
+import numpy as np
 
 
 class GMSH_entity:
@@ -10,6 +11,8 @@ class GMSH_entity:
         gmsh_function_kwargs: dict of keyword arguments for gmsh_function
         dim: dimension of the object (to properly generate dimtag)
         model: meshwell model
+        physical_name: name of the physical this entity wil belong to
+        mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
     """
 
     def __init__(
@@ -18,11 +21,15 @@ class GMSH_entity:
         gmsh_function_kwargs,
         dim,
         model,
+        physical_name,
+        mesh_order=np.inf,
     ):
         self.gmsh_function = gmsh_function
         self.gmsh_function_kwargs = gmsh_function_kwargs
         self.dim = dim
         self.model = model
+        self.mesh_order = mesh_order
+        self.physical_name = physical_name
 
     def instanciate(self):
         """Returns dim tag from entity."""

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -2,7 +2,11 @@ import gmsh
 import numpy as np
 
 
-class GMSH_entity:
+from typing import Any, Dict, Optional
+from pydantic import BaseModel
+
+
+class GMSH_entity(BaseModel):
     """
     Delayed evaluation of a gmsh occ kernel entity.
 
@@ -16,23 +20,13 @@ class GMSH_entity:
         mesh_bool: if True, entity will be meshed; if not, will not be meshed (useful to tag boundaries)
     """
 
-    def __init__(
-        self,
-        gmsh_function,
-        gmsh_function_kwargs,
-        dim,
-        model,
-        physical_name=None,
-        mesh_order=np.inf,
-        mesh_bool=True,
-    ):
-        self.gmsh_function = gmsh_function
-        self.gmsh_function_kwargs = gmsh_function_kwargs
-        self.dim = dim
-        self.model = model
-        self.mesh_order = mesh_order
-        self.physical_name = physical_name
-        self.mesh_bool = mesh_bool
+    gmsh_function: Any
+    gmsh_function_kwargs: Dict[str, Any]
+    dim: int
+    model: Any
+    physical_name: Optional[str] = None
+    mesh_order: float = np.inf
+    mesh_bool: bool = True
 
     def instanciate(self):
         """Returns dim tag from entity."""

--- a/meshwell/labeledentity.py
+++ b/meshwell/labeledentity.py
@@ -4,11 +4,13 @@ import gmsh
 class LabeledEntities:
     """Class to track entities, boundaries, and physical labels during meshing."""
 
-    def __init__(self, index, dimtags, label, base_resolution, resolution, keep, model):
+    def __init__(
+        self, index, dimtags, physical_name, base_resolution, resolution, keep, model
+    ):
         self.index = index
         self.model = model
         self.dimtags = self._fuse_self(dimtags)
-        self.label = label
+        self.physical_name = physical_name
         self.base_resolution = base_resolution
         self.resolution = resolution
         self.boundaries = self.update_boundaries()

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -5,7 +5,11 @@ from typing import Dict, Optional, List, Tuple
 import numpy as np
 
 import gmsh
-from meshwell.validation import validate_dimtags, unpack_dimtags
+from meshwell.validation import (
+    validate_dimtags,
+    unpack_dimtags,
+    consolidate_entities_by_physical_name,
+)
 from meshwell.labeledentity import LabeledEntities
 from meshwell.tag import tag_entities, tag_interfaces, tag_boundaries
 from meshwell.refinement import constant_refinement
@@ -255,6 +259,7 @@ class Model:
                 final_entity_list.append(current_entities)
 
         # Make sure the most up-to-date surfaces are logged as boundaries
+        final_entity_list = consolidate_entities_by_physical_name(final_entity_list)
         for entity in final_entity_list:
             entity.update_boundaries()
 

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -205,9 +205,12 @@ class Model:
 
             enumerator = tqdm(list(enumerator))
 
-        for index, (label, (entity_obj, keep)) in enumerator:
+        for index, (physical_name, (entity_obj, keep)) in enumerator:
+            physical_name = entity_obj.physical_name
+            keep = entity_obj.mesh_bool
             if progress_bars:
-                enumerator.set_description(f"{label:<30}")
+                if physical_name:
+                    enumerator.set_description(f"{physical_name:<30}")
             # First create the shape
             dimtags_out = entity_obj.instanciate()
 
@@ -218,16 +221,18 @@ class Model:
 
             # Assemble with other shapes
             base_resolution = (
-                resolutions[label].get("resolution", default_characteristic_length)
-                if label in resolutions
+                resolutions[physical_name].get(
+                    "resolution", default_characteristic_length
+                )
+                if physical_name in resolutions
                 else default_characteristic_length
             )
             current_entities = LabeledEntities(
                 index=index,
                 dimtags=dimtags,
-                label=label,
+                physical_name=physical_name,
                 base_resolution=base_resolution,
-                resolution=resolutions.get(label, None),
+                resolution=resolutions.get(physical_name, None),
                 keep=keep,
                 model=self.model,
             )

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -1,3 +1,6 @@
+import numpy as np
+
+
 class PolySurface:
     """
     Creates bottom-up GMSH polygonal surfaces formed by list of shapely (multi)polygon.
@@ -5,12 +8,16 @@ class PolySurface:
     Attributes:
         polygons: list of shapely (Multi)Polygon
         model: GMSH model to synchronize
+        physical_name: name of the physical this entity wil belong to
+        mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
     """
 
     def __init__(
         self,
         polygons,
         model,
+        physical_name,
+        mesh_order=np.inf,
     ):
         # Parse (multi)polygons
         self.polygons = list(
@@ -19,6 +26,10 @@ class PolySurface:
 
         # Track gmsh entities for bottom-up volume definition
         self.model = model
+
+        # Mesh order and name
+        self.mesh_order = mesh_order
+        self.physical_name = physical_name
 
     def _parse_coords(self, coords):
         """Chooses z=0 if the provided coordinates are 2D."""

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -16,8 +16,9 @@ class PolySurface:
         self,
         polygons,
         model,
-        physical_name,
+        physical_name=None,
         mesh_order=np.inf,
+        mesh_bool=True,
     ):
         # Parse (multi)polygons
         self.polygons = list(
@@ -30,6 +31,9 @@ class PolySurface:
         # Mesh order and name
         self.mesh_order = mesh_order
         self.physical_name = physical_name
+
+        # Mesh boolean
+        self.mesh_bool = mesh_bool
 
     def _parse_coords(self, coords):
         """Chooses z=0 if the provided coordinates are 2D."""

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -1,7 +1,10 @@
 import numpy as np
+from pydantic import BaseModel, Field, ConfigDict
+from shapely.geometry import Polygon, MultiPolygon
+from typing import List, Optional, Union, Any, Tuple
 
 
-class PolySurface:
+class PolySurface(BaseModel):
     """
     Creates bottom-up GMSH polygonal surfaces formed by list of shapely (multi)polygon.
 
@@ -12,14 +15,32 @@ class PolySurface:
         mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
     """
 
+    polygons: Union[Polygon, List[Polygon], MultiPolygon, List[MultiPolygon]] = Field(
+        ...
+    )
+    model: Any
+    physical_name: Optional[str] = Field(None)
+    mesh_order: float = Field(np.inf)
+    mesh_bool: bool = Field(True)
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     def __init__(
         self,
-        polygons,
-        model,
-        physical_name=None,
-        mesh_order=np.inf,
-        mesh_bool=True,
+        polygons: Union[Polygon, List[Polygon], MultiPolygon, List[MultiPolygon]],
+        model: Any,
+        physical_name: Optional[str] = None,
+        mesh_order: float = np.inf,
+        mesh_bool: bool = True,
     ):
+        super().__init__(
+            polygons=polygons,
+            model=model,
+            physical_name=physical_name,
+            mesh_order=mesh_order,
+            mesh_bool=mesh_bool,
+        )
+
         # Parse (multi)polygons
         self.polygons = list(
             polygons.geoms if hasattr(polygons, "geoms") else [polygons]
@@ -35,11 +56,11 @@ class PolySurface:
         # Mesh boolean
         self.mesh_bool = mesh_bool
 
-    def _parse_coords(self, coords):
+    def _parse_coords(self, coords: Tuple[float, float]) -> Tuple[float, float, float]:
         """Chooses z=0 if the provided coordinates are 2D."""
         return (coords[0], coords[1], 0) if len(coords) == 2 else coords
 
-    def get_gmsh_polygons(self):
+    def get_gmsh_polygons(self) -> List[int]:
         """Returns the fused GMSH surfaces within model from the polygons."""
         surfaces = [self.add_surface_with_holes(entry) for entry in self.polygons]
         if len(surfaces) <= 1:
@@ -53,7 +74,7 @@ class PolySurface:
         self.model.occ.synchronize()
         return [tag for dim, tag in dimtags]
 
-    def add_surface_with_holes(self, polygon):
+    def add_surface_with_holes(self, polygon: Polygon) -> int:
         """Returns surface, removing intersection with hole surfaces."""
         exterior = self.model.add_surface(
             [self._parse_coords(coords) for coords in polygon.exterior.coords]
@@ -72,7 +93,7 @@ class PolySurface:
             exterior = exterior[0][0][1]  # Parse `outDimTags', `outDimTagsMap'
         return exterior
 
-    def instanciate(self):
+    def instanciate(self) -> List[Tuple[int, int]]:
         polysurface = self.get_gmsh_polygons()
         self.model.occ.synchronize()
         return [(2, polysurface)]

--- a/meshwell/prism.py
+++ b/meshwell/prism.py
@@ -10,6 +10,7 @@ class Prism:
         buffers: dict of {z: buffer} used to shrink/grow base polygons at specified z-values
         physical_name: name of the physical this entity wil belong to
         mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
+        mesh_bool: if True, entity will be meshed; if not, will not be meshed (useful to tag boundaries)
     """
 
     def __init__(
@@ -17,8 +18,9 @@ class Prism:
         polygons,
         buffers,
         model,
-        physical_name,
+        physical_name=None,
         mesh_order=np.inf,
+        mesh_bool=True,
     ):
         # Model
         self.model = model
@@ -29,6 +31,7 @@ class Prism:
         # Mesh order and name
         self.mesh_order = mesh_order
         self.physical_name = physical_name
+        self.mesh_bool = mesh_bool
 
     def get_gmsh_volumes(self):
         """Returns the fused GMSH volumes within model from the polygons and buffers."""

--- a/meshwell/refinement.py
+++ b/meshwell/refinement.py
@@ -1,4 +1,10 @@
-def constant_refinement(final_entity_list, refinement_field_index, model):
+from typing import List, Tuple
+import gmsh
+
+
+def constant_refinement(
+    final_entity_list: List, refinement_field_index: int, model: gmsh.model
+) -> Tuple[List[int], int]:
     # Refine
     n = refinement_field_index
     refinement_fields = []

--- a/meshwell/tag.py
+++ b/meshwell/tag.py
@@ -5,15 +5,16 @@ from itertools import combinations
 def tag_entities(entity_list):
     """Adds physical labels to the entities in the model."""
     for entities in entity_list:
-        gmsh.model.addPhysicalGroup(
-            entities.get_dim(), entities.get_tags(), name=entities.label
-        )
+        if entities.physical_name:
+            gmsh.model.addPhysicalGroup(
+                entities.get_dim(), entities.get_tags(), name=entities.physical_name
+            )
 
 
 def tag_interfaces(entity_list, max_dim, boundary_delimiter):
     """Adds physical labels to the interfaces between entities in entity_list."""
     for entity1, entity2 in combinations(entity_list, 2):
-        if entity1.label == entity2.label:
+        if entity1.physical_name == entity2.physical_name:
             continue
         elif entity1.get_dim() != entity2.get_dim():
             continue
@@ -29,7 +30,7 @@ def tag_interfaces(entity_list, max_dim, boundary_delimiter):
             gmsh.model.addPhysicalGroup(
                 max_dim - 1,
                 common_interfaces,
-                name=f"{entity1.label}{boundary_delimiter}{entity2.label}",
+                name=f"{entity1.physical_name}{boundary_delimiter}{entity2.physical_name}",
             )
 
     return entity_list
@@ -44,5 +45,5 @@ def tag_boundaries(entity_list, max_dim, boundary_delimiter, mesh_edge_name):
         gmsh.model.addPhysicalGroup(
             max_dim - 1,
             boundaries,
-            name=f"{entity.label}{boundary_delimiter}{mesh_edge_name}",
+            name=f"{entity.physical_name}{boundary_delimiter}{mesh_edge_name}",
         )

--- a/meshwell/tag.py
+++ b/meshwell/tag.py
@@ -1,8 +1,9 @@
+from typing import List
 import gmsh
 from itertools import combinations
 
 
-def tag_entities(entity_list):
+def tag_entities(entity_list: List):
     """Adds physical labels to the entities in the model."""
     for entities in entity_list:
         if entities.physical_name:
@@ -11,7 +12,7 @@ def tag_entities(entity_list):
             )
 
 
-def tag_interfaces(entity_list, max_dim, boundary_delimiter):
+def tag_interfaces(entity_list: List, max_dim: int, boundary_delimiter: str):
     """Adds physical labels to the interfaces between entities in entity_list."""
     for entity1, entity2 in combinations(entity_list, 2):
         if entity1.physical_name == entity2.physical_name:
@@ -36,7 +37,9 @@ def tag_interfaces(entity_list, max_dim, boundary_delimiter):
     return entity_list
 
 
-def tag_boundaries(entity_list, max_dim, boundary_delimiter, mesh_edge_name):
+def tag_boundaries(
+    entity_list: List, max_dim: int, boundary_delimiter: str, mesh_edge_name: str
+):
     """Adds physical labels to the boundaries of the entities in entity_list."""
     for entity in entity_list:
         if entity.get_dim() != max_dim:

--- a/meshwell/validation.py
+++ b/meshwell/validation.py
@@ -2,7 +2,7 @@ def validate_dimtags(dimtags):
     dims = [dim for dim, tag in dimtags]
     if len(set(dims)) != 1:
         raise ValueError(
-            "All the entities corresponding to a mesh label must be of the same dimension."
+            "All the entities corresponding to a mesh physical_name must be of the same dimension."
         )
     else:
         return dims[0]

--- a/meshwell/validation.py
+++ b/meshwell/validation.py
@@ -14,3 +14,8 @@ def unpack_dimtags(dimtags):
     if any(isinstance(el, list) for el in tags):
         tags = [item for sublist in tags for item in sublist]
     return [(dim, tag) for tag in tags]
+
+
+def sort_entities_by_mesh_order(entities):
+    """Returns a list of entities, sorted by mesh_order."""
+    return sorted(entities, key=lambda entity: entity.mesh_order)

--- a/meshwell/validation.py
+++ b/meshwell/validation.py
@@ -1,3 +1,6 @@
+from meshwell.labeledentity import LabeledEntities
+
+
 def validate_dimtags(dimtags):
     dims = [dim for dim, tag in dimtags]
     if len(set(dims)) != 1:
@@ -19,3 +22,31 @@ def unpack_dimtags(dimtags):
 def sort_entities_by_mesh_order(entities):
     """Returns a list of entities, sorted by mesh_order."""
     return sorted(entities, key=lambda entity: entity.mesh_order)
+
+
+def consolidate_entities_by_physical_name(entities):
+    """Returns a new list of LabeledEntities, with a single entity per physical_name."""
+    consolidated_entities = []
+    physical_name_dict = {}
+
+    for entity in entities:
+        if entity.physical_name not in physical_name_dict:
+            physical_name_dict[entity.physical_name] = entity
+        else:
+            existing_entity = physical_name_dict[entity.physical_name]
+            combined_dimtags = existing_entity.dimtags + entity.dimtags
+            combined_entity = LabeledEntities(
+                index=existing_entity.index,
+                dimtags=combined_dimtags,
+                physical_name=existing_entity.physical_name,
+                base_resolution=existing_entity.base_resolution,
+                resolution=existing_entity.resolution,
+                keep=existing_entity.keep,
+                model=existing_entity.model,
+            )
+            physical_name_dict[entity.physical_name] = combined_entity
+
+    for entity in physical_name_dict.values():
+        consolidated_entities.append(entity)
+
+    return consolidated_entities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "shapely",
     "gmsh",
     "meshio",
-    "tqdm"
+    "tqdm",
+    "pydantic"
 ]
 readme = "README.md"
 requires-python = ">=3.7"

--- a/tests/test_buffers_prism.py
+++ b/tests/test_buffers_prism.py
@@ -1,0 +1,23 @@
+import pytest
+from shapely.geometry import Point
+from meshwell.model import Model
+from meshwell.prism import Prism
+
+
+def test_prism_value_error():
+    inner_radius = 3
+    outer_radius = 5
+
+    inner_circle = Point(0, 0).buffer(inner_radius)
+    outer_circle = Point(0, 0).buffer(outer_radius)
+
+    ring = outer_circle.difference(inner_circle)
+
+    polygons = ring
+    # Buffers that will cause a change in the topology of the polygon
+    buffers = {0: 0, -1: 0, -1.001: 10, -5: 0}
+
+    model = Model()
+
+    with pytest.raises(ValueError):
+        Prism(polygons=polygons, buffers=buffers, model=model)

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -5,7 +5,6 @@ from meshwell.prism import Prism
 from meshwell.polysurface import PolySurface
 from meshwell.model import Model
 from meshwell.gmsh_entity import GMSH_entity
-from collections import OrderedDict
 
 
 def test_mesh_3D():
@@ -19,28 +18,31 @@ def test_mesh_3D():
     buffers = {0.0: 0.0, 1.0: -0.1}
 
     model = Model()
-    poly3D = Prism(polygons=polygon, buffers=buffers, model=model)
+    poly3D = Prism(
+        polygons=polygon,
+        buffers=buffers,
+        model=model,
+        physical_name="first_entity",
+        mesh_order=1,
+    )
 
     gmsh_entity = GMSH_entity(
         gmsh_function=model.occ.addSphere,
         gmsh_function_kwargs={"xc": 0, "yc": 0, "zc": 0, "radius": 1},
         dim=3,
         model=model,
+        physical_name="second_entity",
+        mesh_order=2,
     )
 
-    entities_dict = OrderedDict(
-        {
-            "first_entity": poly3D,
-            "second_entity": gmsh_entity,
-        }
-    )
+    entities_list = [poly3D, gmsh_entity]
 
     resolutions = {
         "first_entity": {"resolution": 0.3},
     }
 
     model.mesh(
-        entities_dict=entities_dict,
+        entities_list=entities_list,
         resolutions=resolutions,
         default_characteristic_length=0.5,
         verbosity=False,
@@ -59,28 +61,27 @@ def test_mesh_2D():
     polygon = shapely.MultiPolygon([polygon1, polygon2])
 
     model = Model()
-    poly2D = PolySurface(polygons=polygon, model=model)
+    poly2D = PolySurface(
+        polygons=polygon, model=model, physical_name="first_entity", mesh_order=1
+    )
 
     gmsh_entity = GMSH_entity(
         gmsh_function=model.occ.add_rectangle,
         gmsh_function_kwargs={"x": 3, "y": 3, "z": 0, "dx": 1, "dy": 1},
         dim=2,
         model=model,
+        physical_name="second_entity",
+        mesh_order=2,
     )
 
-    entities_dict = OrderedDict(
-        {
-            "first_entity": poly2D,
-            "second_entity": gmsh_entity,
-        }
-    )
+    entities_list = [poly2D, gmsh_entity]
 
     resolutions = {
         "first_entity": {"resolution": 0.3},
     }
 
     model.mesh(
-        entities_dict=entities_dict,
+        entities_list=entities_list,
         resolutions=resolutions,
         default_characteristic_length=0.5,
         verbosity=False,
@@ -92,4 +93,4 @@ def test_mesh_2D():
 
 if __name__ == "__main__":
     test_mesh_3D()
-    test_mesh_2D()
+    # test_mesh_2D()

--- a/tests/test_mesh_order.py
+++ b/tests/test_mesh_order.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import shapely
+from meshwell.polysurface import PolySurface
+from meshwell.model import Model
+from meshwell.validation import sort_entities_by_mesh_order
+
+
+def test_mesh_order():
+    polygon = shapely.box(xmin=0, ymin=1, xmax=1, ymax=1)
+
+    model = Model()
+
+    entities = [
+        PolySurface(
+            polygons=polygon, model=model, mesh_order=10, physical_name="mesh10"
+        ),
+        PolySurface(polygons=polygon, model=model, mesh_order=2, physical_name="mesh2"),
+        PolySurface(polygons=polygon, model=model, physical_name="meshdefault"),
+        PolySurface(
+            polygons=polygon, model=model, mesh_order=3.5, physical_name="mesh3p5"
+        ),
+    ]
+
+    assert entities[0].physical_name == "mesh10"
+    assert entities[1].physical_name == "mesh2"
+    assert entities[2].physical_name == "meshdefault"
+    assert entities[3].physical_name == "mesh3p5"
+
+    ordered_entities = sort_entities_by_mesh_order(entities)
+
+    assert ordered_entities[0].physical_name == "mesh2"
+    assert ordered_entities[1].physical_name == "mesh3p5"
+    assert ordered_entities[2].physical_name == "mesh10"
+    assert ordered_entities[3].physical_name == "meshdefault"
+
+
+if __name__ == "__main__":
+    test_mesh_order()


### PR DESCRIPTION
Changing API:

Currently, we mesh from an OrderedDict of meshwell entities, and use the keys for physical names

With this change, we mesh from a list of meshwell entities, with the meshwell entities having new attributes:
* physical_name: what was previously the dict key
* mesh_order: what was previously the dict order

The advantage of this is that now multiple independent meshwell entities can share the same physical name

This is also required to "break up" ill-formed entities introduced when buffering polygons @HelgeGehring 

Eventually we should also move resolution parameters from a dict to an attribute of the entities