### PR TITLE
default mesh order from order in list

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,9 @@
 # [Changelog](https://keepachangelog.com/en/1.0.0/)
 
-## 1.0.1
+## 1.0.2
 
-Refactoring release, with more to come.
+- default mesh ordering [PR#42](https://github.com/simbilod/meshwell/pull/42)
+## 1.0.1
 
 - resolution dict --> resolution attributes [PR#38](https://github.com/simbilod/meshwell/pull/38)
 

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -1,6 +1,4 @@
 import gmsh
-import numpy as np
-
 
 from typing import Any, Dict, Optional
 from pydantic import BaseModel
@@ -25,9 +23,9 @@ class GMSH_entity(BaseModel):
     dimension: int
     model: Any
     physical_name: Optional[str] = None
-    mesh_order: float = np.inf
+    mesh_order: float | None = None
     mesh_bool: bool = True
-    resolution: Dict | None = None
+    resolution: Dict[str, float] | None = None
 
     def instanciate(self):
         """Returns dim tag from entity."""

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -1,4 +1,3 @@
-import numpy as np
 from pydantic import BaseModel, Field, ConfigDict
 from shapely.geometry import Polygon, MultiPolygon
 from typing import List, Optional, Union, Any, Tuple, Dict
@@ -20,7 +19,7 @@ class PolySurface(BaseModel):
     )
     model: Any
     physical_name: Optional[str] = Field(None)
-    mesh_order: float = Field(np.inf)
+    mesh_order: float | None = None
     mesh_bool: bool = Field(True)
     dimension: int = Field(2)
     resolution: Dict | None = Field(None)
@@ -32,7 +31,7 @@ class PolySurface(BaseModel):
         polygons: Union[Polygon, List[Polygon], MultiPolygon, List[MultiPolygon]],
         model: Any,
         physical_name: Optional[str] = None,
-        mesh_order: float = np.inf,
+        mesh_order: float | None = None,
         mesh_bool: bool = True,
         resolution: Dict | None = None,
     ):

--- a/meshwell/prism.py
+++ b/meshwell/prism.py
@@ -1,4 +1,3 @@
-import numpy as np
 from typing import List, Dict, Optional, Tuple, Union, Any
 from pydantic import BaseModel, Field, ConfigDict
 from shapely.geometry import Polygon, MultiPolygon
@@ -22,7 +21,7 @@ class Prism(BaseModel):
     buffers: Dict[float, float] = Field(...)
     model: Any
     physical_name: Optional[str] = Field(None)
-    mesh_order: float = Field(np.inf)
+    mesh_order: float | None = None
     mesh_bool: bool = Field(True)
     buffered_polygons: List[Tuple[float, Polygon]] = []
     dimension: int = Field(3)
@@ -36,7 +35,7 @@ class Prism(BaseModel):
         buffers: Dict[float, float],
         model: Any,
         physical_name: Optional[str] = None,
-        mesh_order: float = np.inf,
+        mesh_order: float | None = None,
         mesh_bool: bool = True,
         resolution: Dict | None = None,
     ):

--- a/meshwell/validation.py
+++ b/meshwell/validation.py
@@ -1,4 +1,5 @@
 from meshwell.labeledentity import LabeledEntities
+import math
 
 
 def validate_dimtags(dimtags):
@@ -19,9 +20,32 @@ def unpack_dimtags(dimtags):
     return [(dim, tag) for tag in tags]
 
 
+def assign_mesh_order_from_ordering(entities, start_index: int = 0):
+    """Assigns a mesh_order according to the ordering of entities in the list."""
+    for index, entity in enumerate(entities, start=start_index):
+        entity.mesh_order = index
+    return entities
+
+
 def sort_entities_by_mesh_order(entities):
     """Returns a list of entities, sorted by mesh_order."""
     return sorted(entities, key=lambda entity: entity.mesh_order)
+
+
+def order_entities(entities):
+    """Returns a list of entities, sorted by mesh_order, assigning a mesh order corresponding to the ordering if not defined."""
+    defined_order_entities = [
+        entity for entity in entities if entity.mesh_order is not None
+    ]
+    ordered_defined_entities = sort_entities_by_mesh_order(defined_order_entities)
+    undefined_order_entities = [
+        entity for entity in entities if entity.mesh_order is None
+    ]
+    ordered_undefined_entities = assign_mesh_order_from_ordering(
+        undefined_order_entities,
+        start_index=math.ceil(ordered_defined_entities[-1].mesh_order) + 1,
+    )
+    return ordered_defined_entities + ordered_undefined_entities
 
 
 def consolidate_entities_by_physical_name(entities):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.11",
 	"Operating System :: OS Independent",
 ]
-version="1.0.1"
+version="1.0.2"
 authors = [
     {name = "Simon Bilodeau", email = "sb30@princeton.edu"},
 ]

--- a/tests/test_mesh_order.py
+++ b/tests/test_mesh_order.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shapely
 from meshwell.polysurface import PolySurface
 from meshwell.model import Model
-from meshwell.validation import sort_entities_by_mesh_order
+from meshwell.validation import order_entities
 
 
 def test_mesh_order():
@@ -12,27 +12,33 @@ def test_mesh_order():
     model = Model()
 
     entities = [
+        PolySurface(polygons=polygon, model=model, physical_name="meshdefault1"),
         PolySurface(
             polygons=polygon, model=model, mesh_order=10, physical_name="mesh10"
         ),
         PolySurface(polygons=polygon, model=model, mesh_order=2, physical_name="mesh2"),
-        PolySurface(polygons=polygon, model=model, physical_name="meshdefault"),
+        PolySurface(polygons=polygon, model=model, physical_name="meshdefault2"),
         PolySurface(
             polygons=polygon, model=model, mesh_order=3.5, physical_name="mesh3p5"
         ),
     ]
 
-    assert entities[0].physical_name == "mesh10"
-    assert entities[1].physical_name == "mesh2"
-    assert entities[2].physical_name == "meshdefault"
-    assert entities[3].physical_name == "mesh3p5"
+    assert entities[0].physical_name == "meshdefault1"
+    assert entities[1].physical_name == "mesh10"
+    assert entities[2].physical_name == "mesh2"
+    assert entities[3].physical_name == "meshdefault2"
+    assert entities[4].physical_name == "mesh3p5"
 
-    ordered_entities = sort_entities_by_mesh_order(entities)
+    ordered_entities = order_entities(entities)
 
     assert ordered_entities[0].physical_name == "mesh2"
     assert ordered_entities[1].physical_name == "mesh3p5"
     assert ordered_entities[2].physical_name == "mesh10"
-    assert ordered_entities[3].physical_name == "meshdefault"
+    assert ordered_entities[3].physical_name == "meshdefault1"
+    assert ordered_entities[4].physical_name == "meshdefault2"
+
+    assert ordered_entities[3].mesh_order == 11
+    assert ordered_entities[4].mesh_order == 12
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
if mesh_order is not defined, assigns a mesh order based on order in the list

@HelgeGehring 