### PR TITLE
fuse entities by name flag

### DIFF
--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -270,6 +270,8 @@ class Model:
                     )[0]
                     self.occ.synchronize()
                 final_entity_list.append(entities)
+        else:
+            final_entity_list = consolidated_entity_list
         for entity in final_entity_list:
             entity.update_boundaries()
 

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -156,6 +156,7 @@ class Model:
         finalize: bool = True,
         reinitialize: bool = True,
         periodic_entities: List[Tuple[str, str]] = None,
+        fuse_entities_by_name: bool = False,
     ) -> meshio.Mesh:
         """Creates a GMSH mesh with proper physical tagging from a dict of {labels: list( (GMSH entity dimension, GMSH entity tag) )}.
 
@@ -174,6 +175,7 @@ class Model:
                 see https://mfem.org/mesh-formats/#gmsh-mesh-formats.
             finalize: if True (default), finalizes the GMSH model after execution
             periodic_entities: enforces mesh periodicity between the physical entities
+            fuse_entities_by_name: if True, fuses CAD entities sharing the same physical_name
 
         Returns:
             meshio object with mWesh information
@@ -253,7 +255,21 @@ class Model:
                 final_entity_list.append(current_entities)
 
         # Make sure the most up-to-date surfaces are logged as boundaries
-        final_entity_list = consolidate_entities_by_physical_name(final_entity_list)
+        consolidated_entity_list = consolidate_entities_by_physical_name(
+            final_entity_list
+        )
+        final_entity_list = []
+        if fuse_entities_by_name:
+            for entities in consolidated_entity_list:
+                if len(entities.dimtags) != 1:
+                    entities.dimtags = self.occ.fuse(
+                        [entities.dimtags[0]],
+                        entities.dimtags[1:],
+                        removeObject=True,
+                        removeTool=True,
+                    )[0]
+                    self.occ.synchronize()
+                final_entity_list.append(entities)
         for entity in final_entity_list:
             entity.update_boundaries()
 

--- a/tests/test_fuse.py
+++ b/tests/test_fuse.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import shapely
+from meshwell.polysurface import PolySurface
+from meshwell.model import Model
+
+import numpy as np
+
+
+def test_fuse():
+    polygon1 = shapely.box(xmin=0, ymin=0, xmax=2, ymax=2)
+    polygon2 = shapely.box(xmin=-1, ymin=-1, xmax=1, ymax=1)
+    polygon3 = shapely.box(xmin=-3, ymin=-3, xmax=-2, ymax=-2)
+
+    model = Model()
+
+    entities = [
+        PolySurface(polygons=polygon1, model=model, physical_name="cad1"),
+        PolySurface(polygons=polygon2, model=model, physical_name="cad2"),
+        PolySurface(polygons=polygon3, model=model, physical_name="cad3"),
+    ]
+
+    mesh_unfused = model.mesh(
+        entities_list=entities,
+        verbosity=False,
+        filename="mesh_unfused.msh",
+        fuse_entities_by_name=True,
+    )
+
+    model = Model()
+
+    entities = [
+        PolySurface(polygons=polygon1, model=model, physical_name="cad1"),
+        PolySurface(polygons=polygon2, model=model, physical_name="cad1"),
+        PolySurface(polygons=polygon3, model=model, physical_name="cad1"),
+    ]
+
+    mesh_fused = model.mesh(
+        entities_list=entities,
+        verbosity=False,
+        filename="mesh_fused.msh",
+        fuse_entities_by_name=True,
+        reinitialize=True,
+    )
+
+    dimtags_fused = np.unique(mesh_fused.point_data["gmsh:dim_tags"], axis=0)
+    dimtags_unfused = np.unique(mesh_unfused.point_data["gmsh:dim_tags"], axis=0)
+
+    dimtags_fused_2D = dimtags_fused[np.where(dimtags_fused[:, 0] == 2)]
+    dimtags_unfused_2D = dimtags_unfused[np.where(dimtags_unfused[:, 0] == 2)]
+
+    dimtags_fused_1D = dimtags_fused[np.where(dimtags_fused[:, 0] == 1)]
+    dimtags_unfused_1D = dimtags_unfused[np.where(dimtags_unfused[:, 0] == 1)]
+
+    assert len(dimtags_fused_2D) == 2
+    assert len(dimtags_unfused_2D) == 3
+    assert len(dimtags_fused_1D) < len(dimtags_unfused_1D)  # less interfaces
+
+
+if __name__ == "__main__":
+    test_fuse()


### PR DESCRIPTION
@HelgeGehring 

```
    entities = [
        PolySurface(polygons=polygon1, model=model, physical_name="cad1"),
        PolySurface(polygons=polygon2, model=model, physical_name="cad2"),
        PolySurface(polygons=polygon3, model=model, physical_name="cad3"),
    ]

    mesh_unfused = model.mesh(
        entities_list=entities,
        verbosity=False,
        filename="mesh_unfused.msh",
        fuse_entities_by_name=True,
    )
```

![image](https://github.com/simbilod/meshwell/assets/46427609/8218fb2e-2c67-436f-b72c-3a8c18d82243)

```
    entities = [
        PolySurface(polygons=polygon1, model=model, physical_name="cad1"),
        PolySurface(polygons=polygon2, model=model, physical_name="cad1"),
        PolySurface(polygons=polygon3, model=model, physical_name="cad1"),
    ]

    mesh_fused = model.mesh(
        entities_list=entities,
        verbosity=False,
        filename="mesh_fused.msh",
        fuse_entities_by_name=True,
        reinitialize=True,
    )
```

![image](https://github.com/simbilod/meshwell/assets/46427609/7d61d42e-d423-461f-be2f-6dee0afa6210)

