### PR TITLE
move "Remove boundary entities" after applying refinemen

### DIFF
--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -361,7 +361,6 @@ class Model:
                     ],
                 )
 
-
         # Perform refinement
         if background_remeshing_file is None:
             # Use entity information
@@ -387,7 +386,7 @@ class Model:
             bg_field = self.model.mesh.field.add("PostView")
             self.model.mesh.field.setNumber(bg_field, "ViewIndex", 0)
             gmsh.model.mesh.field.setAsBackgroundMesh(bg_field)
-            
+
         # Remove boundary entities
         for entity in final_entity_list:
             if not entity.keep:

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -361,10 +361,6 @@ class Model:
                     ],
                 )
 
-        # Remove boundary entities
-        for entity in final_entity_list:
-            if not entity.keep:
-                self.model.occ.remove(entity.dimtags, recursive=True)
 
         # Perform refinement
         if background_remeshing_file is None:
@@ -391,6 +387,11 @@ class Model:
             bg_field = self.model.mesh.field.add("PostView")
             self.model.mesh.field.setNumber(bg_field, "ViewIndex", 0)
             gmsh.model.mesh.field.setAsBackgroundMesh(bg_field)
+            
+        # Remove boundary entities
+        for entity in final_entity_list:
+            if not entity.keep:
+                self.model.occ.remove(entity.dimtags, recursive=True)
 
         # Turn off default meshing options
         self.model.mesh.MeshSizeFromPoints = 0


### PR DESCRIPTION
While this change allows refining around physicals that are afterwards removed, it creates "tag not found" errors

We probably should rethink this before we apply it.

Maybe we split between "refining within" and "refining around"?

As we also need more options like curve / point based refinement, we probably want to have a cleaner concept than dictionaries for defining resolutions?