### PR TITLE
Save and load CAD files + housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ cython_debug/
 
 # GMSH
 *.msh
+*.xao

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -41,9 +41,6 @@ class Model:
         gmsh.option.setNumber("Mesh.MaxNumThreads3D", n_threads)
         gmsh.option.setNumber("Geometry.OCCParallel", 1)
 
-        # Point snapping
-        self.point_tolerance = point_tolerance
-
         # CAD engine
         self.model = gmsh.model
         self.occ = self.model.occ

--- a/meshwell/utils.py
+++ b/meshwell/utils.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from meshwell.config import PATH
 
 
-def compare_meshes(meshfile: Path):
+def compare_meshes(meshfile: Path, meshfile2: Path | None = None):
     meshfile1 = meshfile
-    meshfile2 = PATH.references / (str(meshfile.with_suffix("")) + ".reference.msh")
+    meshfile2 = meshfile2 or PATH.references / (
+        str(meshfile.with_suffix("")) + ".reference.msh"
+    )
 
     with open(str(meshfile1)) as f:
         expected_lines = f.readlines()

--- a/tests/test_cad.py
+++ b/tests/test_cad.py
@@ -15,6 +15,7 @@ def test_cad_load():
     entities_list = []
 
     for stagger in range(10):
+        stagger *= 5
         entities_list.append(
             Prism(
                 polygons=shapely.Polygon(
@@ -30,8 +31,9 @@ def test_cad_load():
                 model=model,
                 physical_name=f"prism_{stagger}",
                 mesh_order=stagger,
+                mesh_bool=stagger % 2,
                 resolutions=[
-                    ConstantInField(resolution=10, apply_to="volumes"),
+                    ConstantInField(resolution=20 / (stagger + 1), apply_to="volumes"),
                 ],
             )
         )
@@ -42,6 +44,7 @@ def test_cad_load():
         filename_cad="test_cad.xao",
         load_cad=False,
         filename="test_cad.msh",
+        default_characteristic_length=100,
     )
     end_time = time.time()
     init_time = end_time - start_time
@@ -53,6 +56,7 @@ def test_cad_load():
         filename_cad="test_cad.xao",
         load_cad=True,
         filename="test_load_cad.msh",
+        default_characteristic_length=100,
     )
     end_time = time.time()
     load_time = end_time - start_time

--- a/tests/test_cad.py
+++ b/tests/test_cad.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import shapely
+from meshwell.prism import Prism
+from meshwell.model import Model
+from meshwell.resolution import ConstantInField
+import time
+
+
+def test_mesh_additive_3D():
+    buffers = {0.0: 0.0, 1.0: -0.1}
+
+    model = Model(n_threads=1)
+
+    entities_list = []
+
+    for stagger in range(10):
+        entities_list.append(
+            Prism(
+                polygons=shapely.Polygon(
+                    [
+                        [-5 + stagger, -5 + stagger],
+                        [5 + stagger, -5 + stagger],
+                        [5 + stagger, 5 + stagger],
+                        [-5 + stagger, 5 + stagger],
+                        [-5 + stagger, -5 + stagger],
+                    ],
+                ),
+                buffers=buffers,
+                model=model,
+                physical_name=f"prism_{stagger}",
+                mesh_order=stagger,
+                resolutions=[
+                    ConstantInField(resolution=10, apply_to="volumes"),
+                ],
+            )
+        )
+
+    start_time = time.time()
+    model.mesh(
+        entities_list=entities_list,
+        filename_cad="test_cad.xao",
+        load_cad=False,
+        filename="test_cad.msh",
+    )
+    end_time = time.time()
+    init_time = end_time - start_time
+
+    model2 = Model(n_threads=1)
+    start_time = time.time()
+    model2.mesh(
+        entities_list=entities_list,
+        filename_cad="test_cad.xao",
+        load_cad=True,
+        filename="test_load_cad.msh",
+    )
+    end_time = time.time()
+    load_time = end_time - start_time
+
+    assert load_time < init_time
+
+
+if __name__ == "__main__":
+    test_mesh_additive_3D()

--- a/tests/test_cad.py
+++ b/tests/test_cad.py
@@ -7,7 +7,7 @@ from meshwell.resolution import ConstantInField
 import time
 
 
-def test_mesh_additive_3D():
+def test_cad_load():
     buffers = {0.0: 0.0, 1.0: -0.1}
 
     model = Model(n_threads=1)
@@ -61,4 +61,4 @@ def test_mesh_additive_3D():
 
 
 if __name__ == "__main__":
-    test_mesh_additive_3D()
+    test_cad_load()


### PR DESCRIPTION
New flag in model.mesh() to save the CAD model or reload it from a file instead of computing the booleans again

Ideally these would each be their own methods, but right now the CAD definition and meshing parameters are too intertwined by the Entity input objects; this will need some more thought. For instance this will definitely break if multiple input Entities with different meshing settings share the same physical name, or if additive entities are present.

