### PR TITLE
48 separate cad definition and meshing

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 - importing gds function and example [PR#102](https://github.com/simbilod/meshwell/pull/102)
 - refactor meshing into more manageable chunks, fixing [issue#87](https://github.com/simbilod/meshwell/issues/87) [PR#105](https://github.com/simbilod/meshwell/pull/105) [PR#106](https://github.com/simbilod/meshwell/pull/106)
+- refactor meshing into CAD + meshing to checkpoint [PR#107](https://github.com/simbilod/meshwell/pull/107)
 
 ## 1.3.8
 

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -32,7 +32,7 @@ class GMSH_entity(BaseModel):
     @validator("physical_name", pre=True, always=True)
     def _set_physical_name(cls, physical_name: Optional[str | tuple[str]]):
         if isinstance(physical_name, str):
-            return [physical_name]
+            return (physical_name,)
         else:
             return physical_name
 

--- a/meshwell/labeledentity.py
+++ b/meshwell/labeledentity.py
@@ -20,6 +20,25 @@ class LabeledEntities(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    def to_dict(self) -> dict:
+        """Convert entity to dictionary representation.
+
+        Returns:
+            Dictionary containing serializable entity data
+        """
+        return {
+            "index": self.index,
+            "dimtags": self.dimtags,
+            "physical_name": self.physical_name,
+            "resolutions": [r.model_dump() for r in self.resolutions]
+            if self.resolutions
+            else None,
+            "keep": self.keep,
+            "boundaries": self.boundaries,
+            "interfaces": self.interfaces,
+            "mesh_edge_name_interfaces": self.mesh_edge_name_interfaces,
+        }
+
     def _fuse_self(self, dimtags: List[Union[int, str]]) -> List[Union[int, str]]:
         if len(dimtags) == 0:
             return []

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -26,15 +26,21 @@ class Model:
 
     def __init__(
         self,
+        name: str = "temp",
         point_tolerance: float = 1e-3,
         n_threads: int = cpu_count(),
     ):
         # Initialize model
-        if gmsh.is_initialized():
-            gmsh.clear()
-        gmsh.initialize()
+        if not gmsh.is_initialized():
+            gmsh.initialize()
 
-        # Set paralllel processing
+        # Model naming
+        self.model = gmsh.model
+        self.name = name
+        self.model.add(name)
+        self.model.setFileName(name)
+
+        # Set parallel processing
         gmsh.option.setNumber("General.NumThreads", n_threads)
         gmsh.option.setNumber("Mesh.MaxNumThreads1D", n_threads)
         gmsh.option.setNumber("Mesh.MaxNumThreads2D", n_threads)
@@ -45,7 +51,6 @@ class Model:
         self.point_tolerance = point_tolerance
 
         # CAD engine
-        self.model = gmsh.model
         self.occ = self.model.occ
 
         # Track some gmsh entities for bottom-up volume definition
@@ -170,6 +175,9 @@ class Model:
         optimization_flags: tuple[tuple[str, int]] | None = None,
     ) -> meshio.Mesh:
         """Creates a GMSH mesh with proper physical tagging."""
+        # Select this model
+        self.model.setCurrent(self.name)
+
         # Initialize mesh settings
         self._initialize_mesh_settings(
             verbosity,

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -58,7 +58,7 @@ class PolySurface(BaseModel):
 
         self.mesh_order = mesh_order
         if isinstance(physical_name, str):
-            self.physical_name = [physical_name]
+            self.physical_name = (physical_name,)
         else:
             self.physical_name = physical_name
         self.mesh_bool = mesh_bool

--- a/meshwell/prism.py
+++ b/meshwell/prism.py
@@ -84,7 +84,7 @@ class Prism(BaseModel):
 
         # Format physical name
         if isinstance(physical_name, str):
-            self.physical_name = [physical_name]
+            self.physical_name = (physical_name,)
         else:
             self.physical_name = physical_name
         self.mesh_bool = mesh_bool

--- a/meshwell/utils.py
+++ b/meshwell/utils.py
@@ -3,9 +3,12 @@ from pathlib import Path
 from meshwell.config import PATH
 
 
-def compare_meshes(meshfile: Path):
+def compare_meshes(meshfile: Path, other_meshfile: Path | None = None):
     meshfile2 = meshfile
-    meshfile1 = PATH.references / (str(meshfile.with_suffix("")) + ".reference.msh")
+    if other_meshfile is None:
+        meshfile1 = PATH.references / (str(meshfile.with_suffix("")) + ".reference.msh")
+    else:
+        meshfile1 = other_meshfile
 
     with open(str(meshfile1)) as f:
         expected_lines = f.readlines()
@@ -14,3 +17,32 @@ def compare_meshes(meshfile: Path):
 
     diff = list(unified_diff(expected_lines, actual_lines))
     assert diff == [], f"Mesh {str(meshfile)} differs from its reference!"
+
+
+def compare_mesh_headers(meshfile: Path, other_meshfile: Path | None = None):
+    meshfile2 = meshfile
+    if other_meshfile is None:
+        meshfile1 = PATH.references / (str(meshfile.with_suffix("")) + ".reference.msh")
+    else:
+        meshfile1 = other_meshfile
+
+    with open(str(meshfile1)) as f:
+        expected_lines = []
+        for line in f:
+            expected_lines.append(line)
+            if line.startswith("$Entities"):
+                # Get one more line after $Entities
+                expected_lines.append(next(f))
+                break
+
+    with open(str(meshfile2)) as f:
+        actual_lines = []
+        for line in f:
+            actual_lines.append(line)
+            if line.startswith("$Entities"):
+                # Get one more line after $Entities
+                actual_lines.append(next(f))
+                break
+
+    diff = list(unified_diff(expected_lines, actual_lines))
+    assert diff == [], f"Mesh headers in {str(meshfile)} differ from reference!"

--- a/tests/generate_references.sh
+++ b/tests/generate_references.sh
@@ -6,7 +6,7 @@ source .venv/bin/activate
 
 # Install reference version of the package in editable mode
 sudo apt-get install libglu1-mesa
-uv pip install git+https://github.com/simbilod/meshwell.git@d8dc6d5f51d1fcb58f4141c7a39344c932deb215[dev]
+uv pip install git+https://github.com/simbilod/meshwell.git@af140b69f2d563beed2c5389d27724d77a3429bb[dev]
 
 # Execute all Python files in the current directory
 python generate_references.py --references-path ./references/

--- a/tests/generate_references.sh
+++ b/tests/generate_references.sh
@@ -6,7 +6,7 @@ source .venv/bin/activate
 
 # Install reference version of the package in editable mode
 sudo apt-get install libglu1-mesa
-uv pip install git+https://github.com/simbilod/meshwell.git@ee10c5ab5da9c1311f5925907e08e494157c702d[dev]
+uv pip install git+https://github.com/simbilod/meshwell.git@d8dc6d5f51d1fcb58f4141c7a39344c932deb215[dev]
 
 # Execute all Python files in the current directory
 python generate_references.py --references-path ./references/

--- a/tests/test_cad_load.py
+++ b/tests/test_cad_load.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import pytest
+import shapely
+from pathlib import Path
+from meshwell.model import Model
+from meshwell.prism import Prism
+from meshwell.gmsh_entity import GMSH_entity
+from meshwell.resolution import ConstantInField
+
+from meshwell.utils import compare_mesh_headers
+
+
+def test_load_cad_model():
+    # Create initial model with some geometry
+    initial_model = Model(n_threads=1)
+
+    # Create a prism from polygons
+    polygon1 = shapely.Polygon(
+        [[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]],
+        holes=([[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5], [0.5, 0.5]],),
+    )
+    polygon2 = shapely.Polygon([[-1, -1], [-2, -1], [-2, -2], [-1, -2], [-1, -1]])
+    polygon = shapely.MultiPolygon([polygon1, polygon2])
+
+    buffers = {0.0: 0.0, 1.0: -0.1}
+
+    prism = Prism(
+        polygons=polygon,
+        buffers=buffers,
+        model=initial_model,
+        physical_name="prism_entity",
+        mesh_order=1,
+        resolutions=[
+            ConstantInField(resolution=0.5, apply_to="volumes"),
+        ],
+    )
+
+    # Create a sphere
+    sphere = GMSH_entity(
+        gmsh_function=initial_model.occ.addSphere,
+        gmsh_function_kwargs={"xc": 0, "yc": 0, "zc": 0, "radius": 1},
+        dimension=3,
+        model=initial_model,
+        physical_name="sphere_entity",
+        mesh_order=2,
+        resolutions=[
+            ConstantInField(resolution=0.3, apply_to="volumes"),
+        ],
+    )
+
+    entities_list = [prism, sphere]
+
+    # Mesh directly for baseline
+    initial_model.mesh(entities_list=entities_list, filename="test.msh")
+
+    # Generate initial CAD and save to file
+    initial_model.cad(entities_list=entities_list, filename="test.xao")
+
+    # Create new model to test loading
+    load_identical_model = Model("test_load_model_identical", n_threads=1)
+
+    load_identical_model.mesh(
+        entities_list=entities_list,
+        cad_filename="test.xao",
+        from_cad=True,
+        filename="test_identical.msh",
+    )
+
+    compare_mesh_headers(
+        meshfile=Path("test.msh"), other_meshfile=Path("test_identical.msh")
+    )
+
+    # Create new model to test loading w/ modified entities
+    new_model = Model("test_load_model_modified", n_threads=1)
+
+    # Create new entities with different mesh parameters
+    new_prism = Prism(
+        polygons=polygon,
+        buffers=buffers,
+        model=new_model,
+        physical_name="prism_entity",
+        mesh_order=1,
+        resolutions=[
+            ConstantInField(resolution=0.2, apply_to="volumes"),  # Different resolution
+        ],
+    )
+
+    new_sphere = GMSH_entity(
+        gmsh_function=new_model.occ.addSphere,
+        gmsh_function_kwargs={"xc": 0, "yc": 0, "zc": 0, "radius": 1},
+        dimension=3,
+        model=new_model,
+        physical_name="sphere_entity",
+        mesh_order=2,
+        resolutions=[
+            ConstantInField(
+                resolution=0.15, apply_to="volumes"
+            ),  # Different resolution
+        ],
+    )
+
+    new_entities_list = [new_prism, new_sphere]
+
+    # Create new model to test loading
+    load_modified_model = Model("test_load_model_modified", n_threads=1)
+
+    load_modified_model.mesh(
+        entities_list=new_entities_list,
+        cad_filename="test.xao",
+        from_cad=True,
+        filename="test_modified.msh",
+    )
+
+    compare_mesh_headers(
+        meshfile=Path("test.msh"), other_meshfile=Path("test_modified.msh")
+    )
+
+    # Test loading CAD model
+    modified_entities, max_dim = new_model._load_cad_model(
+        filename="test.xao", entities_list=new_entities_list
+    )
+
+    # Verify results
+    assert len(modified_entities) == 2
+    assert max_dim == 3
+
+    # Check entities maintained correct properties
+    for entity in modified_entities:
+        if entity.physical_name == "prism_entity":
+            assert entity.resolutions[0].resolution == 0.2  # New resolution
+            assert entity.mesh_order == 1
+        elif entity.physical_name == "sphere_entity":
+            assert entity.resolutions[0].resolution == 0.15  # New resolution
+            assert entity.mesh_order == 2
+
+
+def test_load_cad_model_with_additive_entities(tmp_path):
+    """Test that loading fails when additive entities are present"""
+    model = Model(n_threads=1)
+
+    # Create base geometry
+    sphere = GMSH_entity(
+        gmsh_function=model.occ.addSphere,
+        gmsh_function_kwargs={"xc": 0, "yc": 0, "zc": 0, "radius": 1},
+        dimension=3,
+        model=model,
+        physical_name="base_sphere",
+        mesh_order=1,
+    )
+
+    # Create additive geometry
+    additive_sphere = GMSH_entity(
+        gmsh_function=model.occ.addSphere,
+        gmsh_function_kwargs={"xc": 0.5, "yc": 0, "zc": 0, "radius": 0.5},
+        dimension=3,
+        model=model,
+        physical_name="additive_sphere",
+        mesh_order=1,
+        additive=True,  # Make this an additive entity
+    )
+
+    xao_file = tmp_path / "test_additive.xao"
+    entities_list = [sphere, additive_sphere]
+
+    # Should raise ValueError due to additive entities
+    with pytest.raises(
+        ValueError,
+        match="Meshing from a loaded CAD file currently does not support additive entities",
+    ):
+        model._load_cad_model(filename=xao_file, entities_list=entities_list)
+
+
+if __name__ == "__main__":
+    test_load_cad_model()

--- a/tests/test_mesh_order.py
+++ b/tests/test_mesh_order.py
@@ -23,19 +23,19 @@ def test_mesh_order():
         ),
     ]
 
-    assert entities[0].physical_name == ["meshdefault1"]
-    assert entities[1].physical_name == ["mesh10"]
-    assert entities[2].physical_name == ["mesh2"]
-    assert entities[3].physical_name == ["meshdefault2"]
-    assert entities[4].physical_name == ["mesh3p5"]
+    assert entities[0].physical_name == ("meshdefault1",)
+    assert entities[1].physical_name == ("mesh10",)
+    assert entities[2].physical_name == ("mesh2",)
+    assert entities[3].physical_name == ("meshdefault2",)
+    assert entities[4].physical_name == ("mesh3p5",)
 
     ordered_entities = order_entities(entities)
 
-    assert ordered_entities[0].physical_name == ["mesh2"]
-    assert ordered_entities[1].physical_name == ["mesh3p5"]
-    assert ordered_entities[2].physical_name == ["mesh10"]
-    assert ordered_entities[3].physical_name == ["meshdefault1"]
-    assert ordered_entities[4].physical_name == ["meshdefault2"]
+    assert ordered_entities[0].physical_name == ("mesh2",)
+    assert ordered_entities[1].physical_name == ("mesh3p5",)
+    assert ordered_entities[2].physical_name == ("mesh10",)
+    assert ordered_entities[3].physical_name == ("meshdefault1",)
+    assert ordered_entities[4].physical_name == ("meshdefault2",)
 
     assert ordered_entities[3].mesh_order == 11
     assert ordered_entities[4].mesh_order == 12

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -18,6 +18,7 @@ def test_prism():
     buffers = {0.0: 0.0, 0.3: 0.1, 1.0: -0.2}
 
     model = Model(n_threads=1)
+    model._initialize_model()
 
     prism_obj = Prism(polygons=polygon, buffers=buffers, model=model)
     prism_obj.instanciate()
@@ -39,6 +40,7 @@ def test_prism_extruded():
     buffers = {-1.0: 0.0, 1.0: 0.0}
 
     model = Model(n_threads=1)
+    model._initialize_model()
 
     prism_obj = Prism(polygons=polygon, buffers=buffers, model=model)
     dim, tags = prism_obj.instanciate()[0]


### PR DESCRIPTION
further refactor Model to allow separation of cad definition and meshing

other improvements suggest themselves:
* registering entities inside the model (with a method) instead of passing a model to entities
* rethink model initialization; now we clear and create new ones so it always works, but this might have issues when we work on different models in parallel in the future