### PR TITLE
Multidimension entity models

### DIFF
--- a/meshwell/labeledentity.py
+++ b/meshwell/labeledentity.py
@@ -61,7 +61,7 @@ class LabeledEntities(BaseModel):
 
     @property
     def dim(self) -> int:
-        return [dim for dim, tag in self.dimtags][0]
+        return max([dim for dim, tag in self.dimtags])
 
     def update_boundaries(self) -> List[int]:
         self.boundaries = [

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -554,7 +554,7 @@ class Model:
                         f"{str(physical_name):<30} - {'boolean':<15}"
                     )
             if index != 0:
-                cut = self.occ.cut(
+                cut = self.occ.fragment(
                     current_entities.dimtags,
                     [
                         dimtag
@@ -577,7 +577,21 @@ class Model:
                             f"{str(physical_name):<30} - {'sync':<15}"
                         )
                 self.sync_model()
-                current_entities.dimtags = list(set(cut[0]))
+                # Newly appeared dimtags can be assigned to new entity
+                current_entities.dimtags = list(
+                    set(cut[0])
+                    - {
+                        dimtag
+                        for entity in structural_entity_list
+                        for dimtag in entity.dimtags
+                    }
+                )
+                # Filter out dimtags that don't match the entity dimension
+                current_entities.dimtags = [
+                    dimtag
+                    for dimtag in current_entities.dimtags
+                    if dimtag[0] == current_entities.dim
+                ]
             if current_entities.dimtags:
                 structural_entity_list.append(current_entities)
 

--- a/tests/test_multi_dimension.py
+++ b/tests/test_multi_dimension.py
@@ -1,0 +1,30 @@
+from meshwell.model import Model
+from meshwell.gmsh_entity import GMSH_entity
+
+
+def test_multi_dimension_entities():
+    model = Model(n_threads=1, filename="test_multi_dimension_entities")
+
+    box = GMSH_entity(
+        gmsh_function=model.occ.addBox,
+        gmsh_function_kwargs={"x": 0, "y": 0, "z": 0, "dx": 1, "dy": 1, "dz": 1},
+        dimension=3,
+        model=model,
+        physical_name="box3D",
+        mesh_order=2,
+    )
+
+    plane = GMSH_entity(
+        gmsh_function=model.occ.addRectangle,
+        gmsh_function_kwargs={"x": 0.25, "y": 0.25, "z": 0.25, "dx": 0.5, "dy": 0.5},
+        dimension=2,
+        model=model,
+        physical_name="rect2D",
+        mesh_order=1,
+    )
+
+    model.mesh(entities_list=[box, plane])
+
+
+if __name__ == "__main__":
+    test_multi_dimension_entities()

--- a/tests/test_multi_dimension.py
+++ b/tests/test_multi_dimension.py
@@ -23,7 +23,25 @@ def test_multi_dimension_entities():
         mesh_order=1,
     )
 
-    model.mesh(entities_list=[box, plane])
+    box2 = GMSH_entity(
+        gmsh_function=model.occ.addBox,
+        gmsh_function_kwargs={"x": 1, "y": 0, "z": 0, "dx": 1, "dy": 1, "dz": 1},
+        dimension=3,
+        model=model,
+        physical_name="box3D_2",
+        mesh_order=3,
+    )
+
+    plane2 = GMSH_entity(
+        gmsh_function=model.occ.addRectangle,
+        gmsh_function_kwargs={"x": 0.5, "y": 0.5, "z": 0.75, "dx": 1, "dy": 0.5},
+        dimension=2,
+        model=model,
+        physical_name="rect2D_2",
+        mesh_order=2,
+    )
+
+    model.mesh(entities_list=[box, plane, box2, plane2])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
working on automatic tagging of arbitrary dimension entities

- loop over entities from higher dimension (in mesh order) to lower (in their mesh order)
- process entities of the same dimension the usual way (cut --> create labeled entity w/ info)
- if there are entities with higher dimension, embed
  - use occ.fragment, deleting both object and tool: if OCC.PreserveNumbering is True, and if object is lower dimension than tool, this does not change the higher order entity tags
  - the output of occ.fragments has all the dimtags resulting from the operation: filter out the current entity dimension dimtags, and the ones that don't correspond to an existing updated boundary (since higher dim hasn't changed, we can retrieve those again) or a previous entity of same dimension that we cut from (doesn't changed its tags?) should be the embedded ones