### PR TITLE
More generic partials

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- bug fixes [#PR123](https://github.com/simbilod/meshwell/pull/123)
+- arbitrary custom gmsh entities [PR#125](https://github.com/simbilod/meshwell/pull/125)
+
 ## 2.1.0
 
 - support lower-dimensional objects being passed, will be fragmented with higher-dimensional objects [PR#117](https://github.com/simbilod/meshwell/pull/117)

--- a/tests/generate_references.sh
+++ b/tests/generate_references.sh
@@ -6,7 +6,7 @@ source .venv/bin/activate
 
 # Install reference version of the package
 sudo apt-get install libglu1-mesa
-uv pip install git+https://github.com/simbilod/meshwell.git@0c76dc2d12316aa488746f2054c2123c29f32f0d[dev]
+uv pip install git+https://github.com/simbilod/meshwell.git@f71bb31c5fdcb15137d6165c961a9e5f74bb6f99[dev]
 
 # Execute all Python files in the current directory
 python generate_references.py --references-path ./references/

--- a/tests/test_gmsh_entity.py
+++ b/tests/test_gmsh_entity.py
@@ -15,3 +15,42 @@ def test_gmsh_entity():
     )
 
     cad(entities_list=[gmsh_obj], output_file="test_gmsh_entity")
+
+
+def test_custom_partial():
+    def front_face_rectangle(x_min, x_max, y, z_min, z_max):
+        """Assumes model is already initialized."""
+
+        # Define the four corners of the rectangle in 3D space
+        # Front face is at y=y_max, spanning x and z
+        p1 = gmsh.model.occ.addPoint(x_min, y, z_min)
+        p2 = gmsh.model.occ.addPoint(x_max, y, z_min)
+        p3 = gmsh.model.occ.addPoint(x_max, y, z_max)
+        p4 = gmsh.model.occ.addPoint(x_min, y, z_max)
+
+        # Create lines connecting the points
+        l1 = gmsh.model.occ.addLine(p1, p2)
+        l2 = gmsh.model.occ.addLine(p2, p3)
+        l3 = gmsh.model.occ.addLine(p3, p4)
+        l4 = gmsh.model.occ.addLine(p4, p1)
+
+        # Create a curve loop and plane surface
+        loop = gmsh.model.occ.addCurveLoop([l1, l2, l3, l4])
+        surface = gmsh.model.occ.addPlaneSurface([loop])
+
+        return surface
+
+    gmsh_obj = GMSH_entity(
+        gmsh_partial_function=partial(
+            front_face_rectangle, x_min=0, x_max=1, y=0, z_min=0, z_max=1
+        ),
+        physical_name="custom_gmsh_entity",
+        mesh_order=1,
+        dimension=2,
+    )
+
+    cad(entities_list=[gmsh_obj], output_file="custom_gmsh_entity.xao")
+
+
+if __name__ == "__main__":
+    test_custom_partial()


### PR DESCRIPTION
tweak the gmsh_entity logic to admit custom functions that return arbitrary gmsh entities, while comforming to the meshwell delayed evaluation + mesh ordering + naming

