### PR TITLE
Enable more ruff checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
+
     rev: "9260cbc9c84c06022993bfbcc42fdbf0305c5b8e"
     hooks:
       - id: check-added-large-files

--- a/docs/gdsfactory_interface.py
+++ b/docs/gdsfactory_interface.py
@@ -65,7 +65,7 @@
 #     gmsh.initialize()
 #     gmsh.open("heater_uz.msh")
 #     gmsh.fltk.run()
-# except:  # noqa: E722
+# except:
 #     print("Skipping CAD GUI visualization - only available when running locally")
 # ```
 
@@ -93,7 +93,7 @@
 #     gmsh.initialize()
 #     gmsh.open("heater_3D.msh")
 #     gmsh.fltk.run()
-# except:  # noqa: E722
+# except:
 #     print("Skipping CAD GUI visualization - only available when running locally")
 # ```
 # %%

--- a/docs/importing_gds.py
+++ b/docs/importing_gds.py
@@ -7,17 +7,17 @@
 # First, assume we have a GDS file (here we write a small one with gdstk):
 
 # %%
-from typing import List
+
 import gdstk
-from meshwell.import_gds import read_gds_layers
+import matplotlib.pyplot as plt
 import shapely
 import shapely.geometry as sg
-from meshwell.visualization import colors
-from meshwell.polysurface import PolySurface
-import matplotlib.pyplot as plt
-from meshwell.visualization import plot2D
+
 from meshwell.cad import cad
+from meshwell.import_gds import read_gds_layers
 from meshwell.mesh import mesh
+from meshwell.polysurface import PolySurface
+from meshwell.visualization import colors, plot2D
 
 lib = gdstk.Library()
 cell = lib.new_cell("TOP")
@@ -50,7 +50,7 @@ circle3 = gdstk.ellipse((5, 5), 1, layer=3, datatype=0)
 # Add all shapes to cell
 shapes = [rect1a, poly1b, poly1c, rect2a, poly2b, poly2c, circle1, circle2, circle3]
 for shape in shapes:
-    if isinstance(shape, List):
+    if isinstance(shape, list):
         for subshape in shape:
             cell.add(subshape)
     else:
@@ -64,10 +64,7 @@ ymin = float("inf")
 ymax = float("-inf")
 
 for shape in shapes:
-    if isinstance(shape, List):
-        shape_list = shape
-    else:
-        shape_list = [shape]
+    shape_list = shape if isinstance(shape, list) else [shape]
 
     for s in shape_list:
         bbox = s.bounding_box()
@@ -236,7 +233,7 @@ plt.show()
 # %%
 # Helper function to plot shapely geometries
 def plot_geometry(geometry, title=None, color="blue", alpha=0.5, show_layer4=True):
-    fig, ax = plt.subplots(figsize=(8, 8))
+    _fig, ax = plt.subplots(figsize=(8, 8))
 
     # Plot the main geometry
     if isinstance(geometry, sg.MultiPolygon):

--- a/docs/intro_gmsh.py
+++ b/docs/intro_gmsh.py
@@ -5,6 +5,7 @@
 # %%
 import gmsh
 import meshio
+
 from meshwell.visualization import plot2D
 
 # %% [markdown]

--- a/docs/models.py
+++ b/docs/models.py
@@ -3,14 +3,16 @@
 # Multiple GMSH entities (and polysurfaces or prisms) can be provided to a model to create a single mesh.
 
 # %%
-import shapely
-import gmsh
 from functools import partial
-from meshwell.polysurface import PolySurface
-from meshwell.gmsh_entity import GMSH_entity
-from meshwell.visualization import plot2D
+
+import gmsh
+import shapely
+
 from meshwell.cad import cad
+from meshwell.gmsh_entity import GMSH_entity
 from meshwell.mesh import mesh
+from meshwell.polysurface import PolySurface
+from meshwell.visualization import plot2D
 
 # %%
 polygon_hull = shapely.Polygon(

--- a/docs/polysurfaces.py
+++ b/docs/polysurfaces.py
@@ -6,9 +6,9 @@
 import matplotlib.pyplot as plt
 import shapely
 
-from meshwell.polysurface import PolySurface
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polysurface import PolySurface
 from meshwell.visualization import plot2D
 
 # %%

--- a/docs/prisms.py
+++ b/docs/prisms.py
@@ -3,12 +3,13 @@
 # Polygons can be associated with arbitrarily complex extrusion rules to form 3D Prisms.
 
 # %%
-import shapely
 import matplotlib.pyplot as plt
-from meshwell.polyprism import PolyPrism
 import plotly.graph_objects as go
+import shapely
+
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polyprism import PolyPrism
 
 # %%
 # We use shapely as an API to enter polygons

--- a/docs/resolution_advanced.py
+++ b/docs/resolution_advanced.py
@@ -4,11 +4,12 @@
 
 # %%
 import shapely
-from meshwell.polysurface import PolySurface
-from meshwell.visualization import plot2D
-from meshwell.resolution import ConstantInField, ThresholdField
+
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polysurface import PolySurface
+from meshwell.resolution import ConstantInField, ThresholdField
+from meshwell.visualization import plot2D
 
 # %% [markdown]
 # ## Filtering by mass

--- a/docs/resolution_basic.py
+++ b/docs/resolution_basic.py
@@ -3,13 +3,15 @@
 # When defining entities, ResolutionSpecs can be attached to control the mesh size within or near the entity and its boundaries.
 
 # %%
-import shapely
 from collections import OrderedDict
-from meshwell.polysurface import PolySurface
-from meshwell.visualization import plot2D
-from meshwell.resolution import ConstantInField, ThresholdField, ExponentialField
+
+import shapely
+
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polysurface import PolySurface
+from meshwell.resolution import ConstantInField, ExponentialField, ThresholdField
+from meshwell.visualization import plot2D
 
 # %% [markdown]
 # ## Default characteristic length

--- a/meshwell/__init__.py
+++ b/meshwell/__init__.py
@@ -1,4 +1,4 @@
-"""meshwell - GMSH wrapper, with integrated photonics focus"""
+"""meshwell - GMSH wrapper, with integrated photonics focus."""
 
 __version__ = "0.0.1"
 __author__ = "Simon Bilodeau <sb30@princeton.edu>"

--- a/meshwell/cad.py
+++ b/meshwell/cad.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 from os import cpu_count
-from typing import Dict, List, Tuple, Optional
 from pathlib import Path
 
+from meshwell.labeledentity import LabeledEntities
+from meshwell.model import ModelManager
+from meshwell.tag import tag_boundaries, tag_entities, tag_interfaces
 from meshwell.validation import (
     unpack_dimtags,
 )
-from meshwell.labeledentity import LabeledEntities
-from meshwell.tag import tag_entities, tag_interfaces, tag_boundaries
-from meshwell.model import ModelManager
 
 
 class CAD:
@@ -20,7 +19,7 @@ class CAD:
         point_tolerance: float = 1e-3,
         n_threads: int = cpu_count(),
         filename: str = "temp",
-        model: Optional[ModelManager] = None,
+        model: ModelManager | None = None,
     ):
         """Initialize CAD processor.
 
@@ -29,6 +28,7 @@ class CAD:
             n_threads: Number of threads for processing
             filename: Base filename for the model
             model: Optional Model instance to use (creates new if None)
+
         """
         # Use provided model or create new one
         if model is None:
@@ -46,7 +46,7 @@ class CAD:
         self.point_tolerance = point_tolerance
 
         # Shared point cache for geometry entities that support point deduplication
-        self._shared_point_cache: Dict[Tuple[float, float, float], int] = {}
+        self._shared_point_cache: dict[tuple[float, float, float], int] = {}
 
     def _instantiate_entity(
         self, index: int, entity_obj, progress_bars: bool
@@ -74,9 +74,9 @@ class CAD:
 
     def _process_entities(
         self,
-        entities_list: List,
+        entities_list: list,
         progress_bars: bool,
-    ) -> Tuple[List, int]:
+    ) -> tuple[list, int]:
         """Process structura entities."""
         # Separate and order entities
         structural_entities = [e for e in entities_list if not e.additive]
@@ -89,10 +89,9 @@ class CAD:
         return structural_entity_list, max_dim
 
     def _process_multidimensional_entities(
-        self, structural_entities: List, progress_bars: bool
-    ) -> Tuple[List, int]:
+        self, structural_entities: list, progress_bars: bool
+    ) -> tuple[list, int]:
         """Process entities with mixed dimensions using hierarchical approach."""
-
         entity_dimensions = []
         max_dim = 0
         for index, entity_obj in enumerate(structural_entities):
@@ -141,10 +140,10 @@ class CAD:
 
     def _process_dimension_group_fragments(
         self,
-        entity_group: List[LabeledEntities],
+        entity_group: list[LabeledEntities],
         progress_bars: bool,
-        higher_dim_entities: List[LabeledEntities],
-    ) -> List[LabeledEntities]:
+        higher_dim_entities: list[LabeledEntities],
+    ) -> list[LabeledEntities]:
         """Fragment processing for entities against higher dimensional entities."""
         processed_entities = []
 
@@ -194,8 +193,8 @@ class CAD:
         return processed_entities
 
     def _process_dimension_group_cuts(
-        self, entity_group: List, progress_bars: bool
-    ) -> List[LabeledEntities]:
+        self, entity_group: list, progress_bars: bool
+    ) -> list[LabeledEntities]:
         """Process entities of same dimension using cuts."""
         processed_entities = []
 
@@ -236,7 +235,7 @@ class CAD:
 
     def _tag_mesh_components(
         self,
-        final_entity_list: List,
+        final_entity_list: list,
         max_dim: int,
         interface_delimiter: str,
         boundary_delimiter: str,
@@ -272,11 +271,11 @@ class CAD:
 
     def process_entities(
         self,
-        entities_list: List,
+        entities_list: list,
         interface_delimiter: str = "___",
         boundary_delimiter: str = "None",
         progress_bars: bool = False,
-    ) -> List:
+    ) -> list:
         """Process entities and return final entity list (no file I/O).
 
         Args:
@@ -287,6 +286,7 @@ class CAD:
 
         Returns:
             List of processed LabeledEntities
+
         """
         self.model_manager.ensure_initialized(str(self.model_manager.filename))
 
@@ -317,12 +317,13 @@ class CAD:
 
         Args:
             output_file: Output file path (will be suffixed with .xao)
+
         """
         self.model_manager.save_to_xao(output_file)
 
 
 def cad(
-    entities_list: List,
+    entities_list: list,
     output_file: Path,
     point_tolerance: float = 1e-3,
     n_threads: int = cpu_count(),
@@ -330,7 +331,7 @@ def cad(
     interface_delimiter: str = "___",
     boundary_delimiter: str = "None",
     progress_bars: bool = False,
-    model: Optional[ModelManager] = None,
+    model: ModelManager | None = None,
 ) -> None:
     """Utility function that wraps the CAD class for easier usage.
 
@@ -344,6 +345,7 @@ def cad(
         boundary_delimiter: Delimiter for boundary names
         progress_bars: Show progress bars during processing
         model: Optional Model instance to use (creates new if None)
+
     """
     cad_processor = CAD(
         point_tolerance=point_tolerance,

--- a/meshwell/cad.py
+++ b/meshwell/cad.py
@@ -1,4 +1,5 @@
 """Class definition for generating geometry and saving to a CAD file."""
+
 from __future__ import annotations
 
 from os import cpu_count
@@ -61,8 +62,8 @@ class CAD:
         if hasattr(entity_obj, "_set_point_cache"):
             entity_obj._set_point_cache(self._shared_point_cache)
 
-        # instanciate entity
-        dimtags_out = entity_obj.instanciate()
+        # instantiate entity
+        dimtags_out = entity_obj.instanciate(self)
         dimtags = unpack_dimtags(dimtags_out)
 
         return LabeledEntities(
@@ -200,7 +201,7 @@ class CAD:
         processed_entities = []
 
         for i, (index, entity_obj) in enumerate(entity_group):
-            # instanciate entity using helper method
+            # instantiate entity using helper method
             current_entity = self._instanciate_entity(index, entity_obj, progress_bars)
 
             if i == 0:

--- a/meshwell/cad.py
+++ b/meshwell/cad.py
@@ -49,7 +49,7 @@ class CAD:
         # Shared point cache for geometry entities that support point deduplication
         self._shared_point_cache: dict[tuple[float, float, float], int] = {}
 
-    def _instantiate_entity(
+    def _instanciate_entity(
         self, index: int, entity_obj, progress_bars: bool
     ) -> LabeledEntities:
         """Common logic for instantiating entities."""
@@ -61,7 +61,7 @@ class CAD:
         if hasattr(entity_obj, "_set_point_cache"):
             entity_obj._set_point_cache(self._shared_point_cache)
 
-        # Instantiate entity
+        # instanciate entity
         dimtags_out = entity_obj.instanciate(self)
         dimtags = unpack_dimtags(dimtags_out)
 
@@ -200,8 +200,8 @@ class CAD:
         processed_entities = []
 
         for i, (index, entity_obj) in enumerate(entity_group):
-            # Instantiate entity using helper method
-            current_entity = self._instantiate_entity(index, entity_obj, progress_bars)
+            # instanciate entity using helper method
+            current_entity = self._instanciate_entity(index, entity_obj, progress_bars)
 
             if i == 0:
                 processed_entities.append(current_entity)

--- a/meshwell/cad.py
+++ b/meshwell/cad.py
@@ -62,7 +62,7 @@ class CAD:
             entity_obj._set_point_cache(self._shared_point_cache)
 
         # instanciate entity
-        dimtags_out = entity_obj.instanciate(self)
+        dimtags_out = entity_obj.instanciate()
         dimtags = unpack_dimtags(dimtags_out)
 
         return LabeledEntities(

--- a/meshwell/cad.py
+++ b/meshwell/cad.py
@@ -1,3 +1,4 @@
+"""Class definition for generating geometry and saving to a CAD file."""
 from __future__ import annotations
 
 from os import cpu_count

--- a/meshwell/geometry_entity.py
+++ b/meshwell/geometry_entity.py
@@ -1,3 +1,4 @@
+"""Class definition for entities that create GMHS geometry."""
 from __future__ import annotations
 
 import gmsh
@@ -34,7 +35,9 @@ class GeometryEntity:
         """Add a point to the model, or reuse a previously-defined point within tolerance.
 
         Args:
-            x, y, z: Point coordinates
+            x: x-coordinate
+            y: y-coordinate
+            z: z-coordinate
 
         Returns:
             GMSH point ID
@@ -61,7 +64,8 @@ class GeometryEntity:
         """Add a line to the model, or reuse a previously-defined line between the same points.
 
         Args:
-            point1_id, point2_id: GMSH point IDs
+            point1_id: GMSH point ID #1
+            point2_id: GMSH point ID #2
 
         Returns:
             GMSH line ID

--- a/meshwell/geometry_entity.py
+++ b/meshwell/geometry_entity.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import gmsh
 
+from meshwell.cad import CAD
+
 
 class GeometryEntity:
     """Base class for geometry entities that create GMSH geometry directly.
@@ -125,7 +127,7 @@ class GeometryEntity:
         if self._lines is not None:
             self._lines.clear()
 
-    def instanciate(self, cad_model) -> list[tuple[int, int]]:
+    def instanciate(self, cad_model: CAD | None = None) -> list[tuple[int, int]]:
         """Create GMSH geometry. To be implemented by subclasses.
 
         Args:

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -1,6 +1,7 @@
-import gmsh
 from functools import partial
-from typing import Optional
+
+import gmsh
+
 from meshwell.validation import format_physical_name
 
 GMSH_ENTITY_DIMENSIONS = {
@@ -56,8 +57,7 @@ GMSH_ENTITY_DIMENSIONS = {
 
 
 class GMSH_entity:
-    """
-    Delayed evaluation of a gmsh occ kernel entity.
+    """Delayed evaluation of a gmsh occ kernel entity.
 
     Attributes:
         gmsh_partial_function: entity-defining function from model.occ
@@ -65,12 +65,13 @@ class GMSH_entity:
         physical_name: name(s) of the physical this entity will belong to
         mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
         mesh_bool: if True, entity will be meshed; if not, will not be meshed
+
     """
 
     def __init__(
         self,
         gmsh_partial_function: callable,
-        physical_name: Optional[str | tuple[str]] = None,
+        physical_name: str | tuple[str] | None = None,
         mesh_order: float | None = None,
         mesh_bool: bool = True,
         additive: bool = False,

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -98,7 +98,7 @@ class GMSH_entity:
                 )
             self.dimension = dimension
 
-    def instantiate(self, cad_model):
+    def instanciate(self, cad_model):
         """Returns dim tag from entity.
 
         TODO: properly use cad_model instead of relying on general gmsh.model (being activated)

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -1,3 +1,5 @@
+"""Class definition for delayed gmhs entity evaluation."""
+
 from functools import partial
 
 import gmsh
@@ -96,7 +98,7 @@ class GMSH_entity:
                 )
             self.dimension = dimension
 
-    def instanciate(self, cad_model):
+    def instantiate(self, cad_model):
         """Returns dim tag from entity.
 
         TODO: properly use cad_model instead of relying on general gmsh.model (being activated)

--- a/meshwell/gmsh_entity.py
+++ b/meshwell/gmsh_entity.py
@@ -4,6 +4,7 @@ from functools import partial
 
 import gmsh
 
+from meshwell.cad import CAD
 from meshwell.validation import format_physical_name
 
 GMSH_ENTITY_DIMENSIONS = {
@@ -98,7 +99,7 @@ class GMSH_entity:
                 )
             self.dimension = dimension
 
-    def instanciate(self, cad_model):
+    def instanciate(self, cad_model: CAD):
         """Returns dim tag from entity.
 
         TODO: properly use cad_model instead of relying on general gmsh.model (being activated)

--- a/meshwell/import_gds.py
+++ b/meshwell/import_gds.py
@@ -1,3 +1,4 @@
+"""GDS import routines."""
 import gdstk
 import shapely.geometry as sg
 from shapely.ops import unary_union

--- a/meshwell/import_gds.py
+++ b/meshwell/import_gds.py
@@ -31,13 +31,11 @@ def gdstk_to_shapely(cell, layer_tuple):
 
     if polygons:
         return unary_union(polygons)
-    else:
-        return sg.MultiPolygon([])
+    return sg.MultiPolygon([])
 
 
 def read_gds_layers(gds_file, cell_name=None, layers=None):
     """Read GDS file and convert to Shapely geometries."""
-
     # Read the GDS file
     library = gdstk.read_gds(gds_file)
 

--- a/meshwell/mesh.py
+++ b/meshwell/mesh.py
@@ -1,3 +1,4 @@
+"""Mesh class definition."""
 from __future__ import annotations
 
 import contextlib
@@ -73,7 +74,7 @@ class Mesh:
         self.model_manager.sync_model()
 
     def _apply_periodic_boundaries(
-        self, final_entity_list: list, periodic_entities: list[tuple[str, str]]
+        self, periodic_entities: list[tuple[str, str]]
     ) -> None:
         """Apply periodic boundary conditions."""
         mapping = {
@@ -160,7 +161,6 @@ class Mesh:
 
         Returns:
             Tuple of (final_entity_list, final_entity_dict)
-
         """
         final_entity_list = []
         final_entity_dict = {}
@@ -195,8 +195,8 @@ class Mesh:
         """Apply mesh refinement based on entity information.
 
         Args:
-            final_entity_list: List of LabeledEntities to process
             boundary_delimiter: String used to identify boundary entities
+            resolution_specs: Resolution specifications
 
         """
         # Recover labeled entities from loaded CAD model
@@ -261,11 +261,12 @@ class Mesh:
                 self.model_manager.model.mesh.optimize(optimization_flag, niter=niter)
 
         # Return mesh object without writing to file
-        with contextlib.redirect_stdout(None):
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                temp_mesh_path = f"{tmpdirname}/mesh.msh"
-                gmsh.write(temp_mesh_path)
-                return meshio.read(temp_mesh_path)
+        with contextlib.redirect_stdout(
+            None
+        ), tempfile.TemporaryDirectory() as tmpdirname:
+            temp_mesh_path = f"{tmpdirname}/mesh.msh"
+            gmsh.write(temp_mesh_path)
+            return meshio.read(temp_mesh_path)
 
     def save_to_file(self, output_file: Path) -> None:
         """Save current mesh to file.
@@ -281,6 +282,7 @@ class Mesh:
 
         Args:
             output_file: Output file path (will be suffixed with .format)
+            format: File format to use in gmsh
 
         """
         self.model_manager.save_to_mesh(output_file, format)
@@ -292,11 +294,12 @@ class Mesh:
             meshio.Mesh: Current mesh as meshio object
 
         """
-        with contextlib.redirect_stdout(None):
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                temp_mesh_path = f"{tmpdirname}/mesh.msh"
-                gmsh.write(temp_mesh_path)
-                return meshio.read(temp_mesh_path)
+        with contextlib.redirect_stdout(
+            None
+        ), tempfile.TemporaryDirectory() as tmpdirname:
+            temp_mesh_path = f"{tmpdirname}/mesh.msh"
+            gmsh.write(temp_mesh_path)
+            return meshio.read(temp_mesh_path)
 
     def load_xao_file(self, input_file: Path) -> None:
         """Load CAD geometry from .xao file.
@@ -317,7 +320,7 @@ class Mesh:
         global_3D_algorithm: int = 1,
         mesh_element_order: int = 1,
         verbosity: int | None = 0,
-        periodic_entities: list[tuple[str, str]] | None = None,
+        periodic_entities: list[tuple[str, str]] | None = None,  # noqa: ARG002
         optimization_flags: tuple[tuple[str, int]] | None = None,
         boundary_delimiter: str = "None",
         resolution_specs: dict = (),
@@ -393,6 +396,7 @@ def mesh(
     """Utility function that wraps the Mesh class for easier usage.
 
     Args:
+        dim: Dimension of mesh to generate
         input_file: Path to input .xao file
         output_file: Path for output mesh file
         entities_list: Optional list of entities with mesh parameters
@@ -401,6 +405,7 @@ def mesh(
         global_scaling: Global scaling factor
         global_2D_algorithm: GMSH 2D meshing algorithm
         global_3D_algorithm: GMSH 3D meshing algorithm
+        mesh_element_order: Element order
         verbosity: GMSH verbosity level
         periodic_entities: List of periodic boundary pairs
         optimization_flags: Mesh optimization flags

--- a/meshwell/mesh.py
+++ b/meshwell/mesh.py
@@ -4,7 +4,7 @@ import contextlib
 import tempfile
 from os import cpu_count
 from pathlib import Path
-from typing import Optional, List, Tuple, Dict
+
 import gmsh
 import meshio
 import numpy as np
@@ -20,7 +20,7 @@ class Mesh:
         self,
         n_threads: int = cpu_count(),
         filename: str = "temp",
-        model: Optional[ModelManager] = None,
+        model: ModelManager | None = None,
     ):
         """Initialize mesh generator.
 
@@ -28,6 +28,7 @@ class Mesh:
             n_threads: Number of threads for processing
             filename: Base filename for the model
             model: Optional Model instance to use (creates new if None)
+
         """
         # Use provided model or create new one
         if model is None:
@@ -40,7 +41,7 @@ class Mesh:
             self.model_manager = model
             self._owns_model = False
 
-    def _initialize_model(self, input_file: Optional[Path] = None) -> None:
+    def _initialize_model(self, input_file: Path | None = None) -> None:
         """Initialize GMSH model and optionally load .xao file."""
         # Initialize the model instance
         self.model_manager.ensure_initialized("temp")
@@ -56,7 +57,7 @@ class Mesh:
         default_characteristic_length: float,
         global_2D_algorithm: int,
         global_3D_algorithm: int,
-        gmsh_version: Optional[float],
+        gmsh_version: float | None,
         mesh_element_order: int = 1,
     ) -> None:
         """Initialize basic mesh settings."""
@@ -72,7 +73,7 @@ class Mesh:
         self.model_manager.sync_model()
 
     def _apply_periodic_boundaries(
-        self, final_entity_list: List, periodic_entities: List[Tuple[str, str]]
+        self, final_entity_list: list, periodic_entities: list[tuple[str, str]]
     ) -> None:
         """Apply periodic boundary conditions."""
         mapping = {
@@ -86,7 +87,7 @@ class Mesh:
 
             self._set_periodic_pair(mapping, label1, label2)
 
-    def _set_periodic_pair(self, mapping: Dict, label1: str, label2: str) -> None:
+    def _set_periodic_pair(self, mapping: dict, label1: str, label2: str) -> None:
         """Set up periodic boundary pair."""
         tags1 = self.model_manager.model.getEntitiesForPhysicalGroup(*mapping[label1])
         tags2 = self.model_manager.model.getEntitiesForPhysicalGroup(*mapping[label2])
@@ -108,9 +109,9 @@ class Mesh:
 
     def _apply_mesh_refinement(
         self,
-        background_remeshing_file: Optional[Path] | None,
+        background_remeshing_file: Path | None | None,
         boundary_delimiter: str,
-        resolution_specs: Dict,
+        resolution_specs: dict,
     ) -> None:
         """Apply mesh refinement settings.
 
@@ -126,6 +127,7 @@ class Mesh:
 
         Returns:
             List of physical names as strings
+
         """
         return self.model_manager.get_top_physical_names()
 
@@ -134,6 +136,7 @@ class Mesh:
 
         Returns:
             List of physical names as strings
+
         """
         return self.model_manager.get_physical_names()
 
@@ -145,10 +148,11 @@ class Mesh:
 
         Returns:
             List of (dim, tag) tuples for entities in the physical group
+
         """
         return self.model_manager.get_physical_dimtags(physical_name)
 
-    def _recover_labels_from_cad(self, resolution_specs: Dict) -> Tuple[List, Dict]:
+    def _recover_labels_from_cad(self, resolution_specs: dict) -> tuple[list, dict]:
         """Recover labeled entities from loaded CAD model.
 
         Args:
@@ -156,6 +160,7 @@ class Mesh:
 
         Returns:
             Tuple of (final_entity_list, final_entity_dict)
+
         """
         final_entity_list = []
         final_entity_dict = {}
@@ -165,10 +170,7 @@ class Mesh:
         all_physical_names = self.get_all_physical_names()
 
         for index, physical_name in enumerate(all_physical_names):
-            if physical_name in resolution_specs:
-                resolutions = resolution_specs[physical_name]
-            else:
-                resolutions = []
+            resolutions = resolution_specs.get(physical_name, [])
             if not resolutions and physical_name not in top_physical_names:
                 continue
 
@@ -188,13 +190,14 @@ class Mesh:
     def _apply_entity_refinement(
         self,
         boundary_delimiter: str,
-        resolution_specs: Dict,
+        resolution_specs: dict,
     ) -> None:
         """Apply mesh refinement based on entity information.
 
         Args:
             final_entity_list: List of LabeledEntities to process
             boundary_delimiter: String used to identify boundary entities
+
         """
         # Recover labeled entities from loaded CAD model
         final_entity_list, final_entity_dict = self._recover_labels_from_cad(
@@ -269,6 +272,7 @@ class Mesh:
 
         Args:
             output_file: Output mesh file path
+
         """
         self.model_manager.save_to_mesh(output_file)
 
@@ -277,6 +281,7 @@ class Mesh:
 
         Args:
             output_file: Output file path (will be suffixed with .format)
+
         """
         self.model_manager.save_to_mesh(output_file, format)
 
@@ -285,6 +290,7 @@ class Mesh:
 
         Returns:
             meshio.Mesh: Current mesh as meshio object
+
         """
         with contextlib.redirect_stdout(None):
             with tempfile.TemporaryDirectory() as tmpdirname:
@@ -297,6 +303,7 @@ class Mesh:
 
         Args:
             input_file: Input .xao file path
+
         """
         self.model_manager.load_from_xao(input_file)
 
@@ -304,16 +311,16 @@ class Mesh:
         self,
         dim: int,
         default_characteristic_length: float,
-        background_remeshing_file: Optional[Path] = None,
+        background_remeshing_file: Path | None = None,
         global_scaling: float = 1.0,
         global_2D_algorithm: int = 6,
         global_3D_algorithm: int = 1,
         mesh_element_order: int = 1,
-        verbosity: Optional[int] = 0,
-        periodic_entities: Optional[List[Tuple[str, str]]] = None,
-        optimization_flags: Optional[tuple[tuple[str, int]]] = None,
-        boundary_delimiter: str = "None",  # noqa: B006
-        resolution_specs: Dict = (),
+        verbosity: int | None = 0,
+        periodic_entities: list[tuple[str, str]] | None = None,
+        optimization_flags: tuple[tuple[str, int]] | None = None,
+        boundary_delimiter: str = "None",
+        resolution_specs: dict = (),
     ) -> meshio.Mesh:
         """Process loaded geometry into mesh (no file I/O).
 
@@ -333,6 +340,7 @@ class Mesh:
 
         Returns:
             meshio.Mesh: Generated mesh object
+
         """
         self._initialize_model()
 
@@ -368,20 +376,20 @@ def mesh(
     input_file: Path,
     output_file: Path,
     default_characteristic_length: float,
-    resolution_specs: Dict | None = None,
-    background_remeshing_file: Optional[Path] = None,
+    resolution_specs: dict | None = None,
+    background_remeshing_file: Path | None = None,
     global_scaling: float = 1.0,
     global_2D_algorithm: int = 6,
     global_3D_algorithm: int = 1,
     mesh_element_order: int = 1,
-    verbosity: Optional[int] = 0,
-    periodic_entities: Optional[List[Tuple[str, str]]] = None,
-    optimization_flags: Optional[tuple[tuple[str, int]]] = None,
+    verbosity: int | None = 0,
+    periodic_entities: list[tuple[str, str]] | None = None,
+    optimization_flags: tuple[tuple[str, int]] | None = None,
     boundary_delimiter: str = "None",
     n_threads: int = cpu_count(),
     filename: str = "temp",
-    model: Optional[ModelManager] = None,
-) -> Optional[meshio.Mesh]:
+    model: ModelManager | None = None,
+) -> meshio.Mesh | None:
     """Utility function that wraps the Mesh class for easier usage.
 
     Args:
@@ -404,6 +412,7 @@ def mesh(
 
     Returns:
         Optional[meshio.Mesh]: Generated mesh object
+
     """
     mesh_generator = Mesh(
         n_threads=n_threads,

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from os import cpu_count
 from pathlib import Path
-from typing import Optional, List, Tuple
+
 import gmsh
 
 
@@ -19,7 +19,7 @@ class ModelManager:
         self,
         n_threads: int = cpu_count(),
         filename: str = "temp",
-        point_tolerance: Optional[float] = None,
+        point_tolerance: float | None = None,
     ):
         """Initialize Model with common settings.
 
@@ -27,6 +27,7 @@ class ModelManager:
             n_threads: Number of threads for GMSH operations
             filename: Base filename for the model
             point_tolerance: Point tolerance for CAD operations (optional)
+
         """
         self.n_threads = n_threads
         self.filename = Path(filename)
@@ -43,11 +44,12 @@ class ModelManager:
         self._cad = None
         self._mesh = None
 
-    def _initialize(self, model_name: Optional[str] = None) -> None:
+    def _initialize(self, model_name: str | None = None) -> None:
         """Initialize GMSH model and set basic configuration.
 
         Args:
             model_name: Optional model name override
+
         """
         if self._is_initialized:
             return
@@ -81,6 +83,7 @@ class ModelManager:
 
         Args:
             output_file: Output file path.
+
         """
         output_file = Path(output_file)
         gmsh.write(str(output_file))
@@ -90,6 +93,7 @@ class ModelManager:
 
         Args:
             input_file: Input .xao file path
+
         """
         self.ensure_initialized("temp")
         input_file = Path(input_file)
@@ -100,6 +104,7 @@ class ModelManager:
 
         Args:
             output_file: Output file path (will be suffixed with .xao)
+
         """
         output_file = Path(output_file).with_suffix(".xao")
         gmsh.write(str(output_file))
@@ -110,11 +115,12 @@ class ModelManager:
         Args:
             output_file: Output file path (will be suffixed with format)
             format: File format (msh, vtk, etc.)
+
         """
         output_file = Path(output_file).with_suffix(f".{format}")
         gmsh.write(str(output_file))
 
-    def get_physical_names(self, dim: Optional[int] = None) -> List[str]:
+    def get_physical_names(self, dim: int | None = None) -> list[str]:
         """Get physical names, optionally filtered by dimension.
 
         Args:
@@ -123,6 +129,7 @@ class ModelManager:
 
         Returns:
             List of physical names as strings
+
         """
         if not self._is_initialized or self.model is None:
             return []
@@ -134,11 +141,12 @@ class ModelManager:
 
         return [self.model.getPhysicalName(d, tag) for d, tag in physical_groups]
 
-    def get_top_physical_names(self) -> List[str]:
+    def get_top_physical_names(self) -> list[str]:
         """Get physical names of highest dimension.
 
         Returns:
             List of physical names as strings
+
         """
         if not self._is_initialized or self.model is None:
             return []
@@ -151,7 +159,7 @@ class ModelManager:
         max_dim = max(dim for dim, _ in physical_groups)
         return self.get_physical_names(dim=max_dim)
 
-    def get_physical_dimtags(self, physical_name: str) -> List[Tuple[int, int]]:
+    def get_physical_dimtags(self, physical_name: str) -> list[tuple[int, int]]:
         """Get dimtags for a physical group name.
 
         Args:
@@ -159,6 +167,7 @@ class ModelManager:
 
         Returns:
             List of (dim, tag) tuples for entities in the physical group
+
         """
         if not self._is_initialized or self.model is None:
             return []
@@ -188,11 +197,12 @@ class ModelManager:
             return
         self.occ.synchronize()
 
-    def clear_and_reinitialize(self, model_name: Optional[str] = None) -> None:
+    def clear_and_reinitialize(self, model_name: str | None = None) -> None:
         """Clear current model and reinitialize.
 
         Args:
             model_name: Optional model name override
+
         """
         self._is_initialized = False
         self._initialize(model_name)
@@ -212,11 +222,12 @@ class ModelManager:
         """Check if model is initialized."""
         return self._is_initialized
 
-    def ensure_initialized(self, model_name: Optional[str] = None) -> None:
+    def ensure_initialized(self, model_name: str | None = None) -> None:
         """Ensure model is initialized, initialize if not.
 
         Args:
             model_name: Optional model name override
+
         """
         if not self._is_initialized:
             self._initialize(model_name)
@@ -232,6 +243,7 @@ class ModelManager:
             model = ModelManager(filename="my_project")
             model.cad.process_entities(entities_list)
             model.save_to_xao("output.xao")
+
         """
         if self._cad is None:
             # Import here to avoid circular imports
@@ -254,6 +266,7 @@ class ModelManager:
             model = ModelManager(filename="my_project")
             model.mesh.load_xao_file("input.xao")
             mesh_obj = model.mesh.process_geometry(dim=3, default_characteristic_length=0.1)
+
         """
         if self._mesh is None:
             # Import here to avoid circular imports

--- a/meshwell/model.py
+++ b/meshwell/model.py
@@ -1,3 +1,4 @@
+"""Main gmsh model definitions."""
 from __future__ import annotations
 
 from os import cpu_count

--- a/meshwell/polyline.py
+++ b/meshwell/polyline.py
@@ -1,26 +1,26 @@
-from shapely.geometry import LineString, MultiLineString
-from typing import List, Optional, Union, Tuple
 import gmsh
+from shapely.geometry import LineString, MultiLineString
 
 from meshwell.geometry_entity import GeometryEntity
 
 
 class PolyLine(GeometryEntity):
-    """
-    Creates bottom-up GMSH wires formed by list of shapely (multi)linestring.
+    """Creates bottom-up GMSH wires formed by list of shapely (multi)linestring.
 
     Attributes:
         linestrings: list of shapely (Multi)LineString
         physical_name: name of the physical this entity will belong to
         mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
+
     """
 
     def __init__(
         self,
-        linestrings: Union[
-            LineString, List[LineString], MultiLineString, List[MultiLineString]
-        ],
-        physical_name: Optional[str | tuple[str, ...]] = None,
+        linestrings: LineString
+        | list[LineString]
+        | MultiLineString
+        | list[MultiLineString],
+        physical_name: str | tuple[str, ...] | None = None,
         mesh_order: float | None = None,
         mesh_bool: bool = True,
         additive: bool = False,
@@ -69,12 +69,10 @@ class PolyLine(GeometryEntity):
         if len(lines) == 1:
             # For a single line, we can return it as-is since GMSH treats it as a wire
             return lines[0]
-        else:
-            # For multiple lines, create a proper wire
-            wire_id = gmsh.model.occ.addWire(lines)
-            return wire_id
+        # For multiple lines, create a proper wire
+        return gmsh.model.occ.addWire(lines)
 
-    def instanciate(self, cad_model) -> List[Tuple[int, int]]:
+    def instanciate(self, cad_model) -> list[tuple[int, int]]:
         """Create GMSH wires directly without using CAD class methods."""
         wires = []
         for linestring in self.linestrings:

--- a/meshwell/polyline.py
+++ b/meshwell/polyline.py
@@ -1,3 +1,4 @@
+"""Gmsh wire definitions."""
 import gmsh
 from shapely.geometry import LineString, MultiLineString
 
@@ -72,7 +73,7 @@ class PolyLine(GeometryEntity):
         # For multiple lines, create a proper wire
         return gmsh.model.occ.addWire(lines)
 
-    def instanciate(self, cad_model) -> list[tuple[int, int]]:
+    def instanciate(self) -> list[tuple[int, int]]:
         """Create GMSH wires directly without using CAD class methods."""
         wires = []
         for linestring in self.linestrings:

--- a/meshwell/polyline.py
+++ b/meshwell/polyline.py
@@ -2,6 +2,7 @@
 import gmsh
 from shapely.geometry import LineString, MultiLineString
 
+from meshwell.cad import CAD
 from meshwell.geometry_entity import GeometryEntity
 
 
@@ -73,7 +74,10 @@ class PolyLine(GeometryEntity):
         # For multiple lines, create a proper wire
         return gmsh.model.occ.addWire(lines)
 
-    def instanciate(self) -> list[tuple[int, int]]:
+    def instanciate(
+        self,
+        cad_model: CAD | None = None,  # noqa: ARG002
+    ) -> list[tuple[int, int]]:
         """Create GMSH wires directly without using CAD class methods."""
         wires = []
         for linestring in self.linestrings:

--- a/meshwell/polyprism.py
+++ b/meshwell/polyprism.py
@@ -304,7 +304,7 @@ class PolyPrism(GeometryEntity):
         model.occ.remove(list(prisms_dimtags))
         return subdivided_prisms
 
-    def instantiate(self, cad_model) -> list[tuple[int, int]]:
+    def instanciate(self, cad_model) -> list[tuple[int, int]]:
         """Create GMSH volumes directly without using CAD class methods."""
         prisms = self._create_volumes_directly()
         gmsh.model.occ.synchronize()

--- a/meshwell/polyprism.py
+++ b/meshwell/polyprism.py
@@ -2,6 +2,7 @@
 import gmsh
 from shapely.geometry import MultiPolygon, Polygon
 
+from meshwell.cad import CAD
 from meshwell.geometry_entity import GeometryEntity
 from meshwell.validation import format_physical_name
 
@@ -304,7 +305,7 @@ class PolyPrism(GeometryEntity):
         model.occ.remove(list(prisms_dimtags))
         return subdivided_prisms
 
-    def instanciate(self, cad_model) -> list[tuple[int, int]]:
+    def instanciate(self, cad_model: CAD) -> list[tuple[int, int]]:
         """Create GMSH volumes directly without using CAD class methods."""
         prisms = self._create_volumes_directly()
         gmsh.model.occ.synchronize()

--- a/meshwell/polyprism.py
+++ b/meshwell/polyprism.py
@@ -1,3 +1,4 @@
+"""Gmsh polyprism definitions."""
 import gmsh
 from shapely.geometry import MultiPolygon, Polygon
 
@@ -180,8 +181,7 @@ class PolyPrism(GeometryEntity):
         exterior: bool,
         interior_index: int,
     ) -> list[tuple[float, float, float]]:
-        """"""
-        # Draw xy surface
+        """Draw xy surface."""
         return (
             [(x, y, polygon_z) for x, y in polygon.exterior.coords]
             if exterior
@@ -304,7 +304,7 @@ class PolyPrism(GeometryEntity):
         model.occ.remove(list(prisms_dimtags))
         return subdivided_prisms
 
-    def instanciate(self, cad_model) -> list[tuple[int, int]]:
+    def instantiate(self, cad_model) -> list[tuple[int, int]]:
         """Create GMSH volumes directly without using CAD class methods."""
         prisms = self._create_volumes_directly()
         gmsh.model.occ.synchronize()

--- a/meshwell/polyprism.py
+++ b/meshwell/polyprism.py
@@ -1,14 +1,12 @@
-from typing import List, Dict, Optional, Tuple, Union
-from shapely.geometry import Polygon, MultiPolygon
-from meshwell.validation import format_physical_name
 import gmsh
+from shapely.geometry import MultiPolygon, Polygon
 
 from meshwell.geometry_entity import GeometryEntity
+from meshwell.validation import format_physical_name
 
 
 class PolyPrism(GeometryEntity):
-    """
-    Creates a bottom-up GMSH "prism" formed by a polygon associated with (optional) z-dependent grow/shrink operations.
+    """Creates a bottom-up GMSH "prism" formed by a polygon associated with (optional) z-dependent grow/shrink operations.
 
     Attributes:
         polygons: list of shapely (Multi)Polygon
@@ -16,13 +14,14 @@ class PolyPrism(GeometryEntity):
         physical_name: name of the physical this entity wil belong to
         mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
         mesh_bool: if True, entity will be meshed; if not, will not be meshed (useful to tag boundaries)
+
     """
 
     def __init__(
         self,
-        polygons: Union[Polygon, List[Polygon], MultiPolygon, List[MultiPolygon]],
-        buffers: Dict[float, float],
-        physical_name: Optional[str | tuple[str, ...]] = None,
+        polygons: Polygon | list[Polygon] | MultiPolygon | list[MultiPolygon],
+        buffers: dict[float, float],
+        physical_name: str | tuple[str, ...] | None = None,
         mesh_order: float | None = None,
         mesh_bool: bool = True,
         additive: bool = False,
@@ -39,8 +38,8 @@ class PolyPrism(GeometryEntity):
             self.zmin, self.zmax = min(buffers.keys()), max(buffers.keys())
         else:
             self.extrude = False
-            self.buffered_polygons: List[
-                Tuple[float, Polygon]
+            self.buffered_polygons: list[
+                tuple[float, Polygon]
             ] = self._get_buffered_polygons(polygons, buffers)
 
         # Store other attributes
@@ -54,7 +53,7 @@ class PolyPrism(GeometryEntity):
         self.mesh_bool = mesh_bool
         self.additive = additive
 
-    def _create_volumes_directly(self) -> List[int]:
+    def _create_volumes_directly(self) -> list[int]:
         """Create GMSH volumes directly without using CAD class methods."""
         if self.extrude:
             surfaces = self._create_surfaces_with_holes_at_z(self.polygons, self.zmin)
@@ -84,8 +83,8 @@ class PolyPrism(GeometryEntity):
         return [tag for dim, tag in fused_dimtags]
 
     def _get_buffered_polygons(
-        self, polygons: List[Polygon], buffers: Dict[float, float]
-    ) -> List[Tuple[float, Polygon]]:
+        self, polygons: list[Polygon], buffers: dict[float, float]
+    ) -> list[tuple[float, Polygon]]:
         """Break up polygons on each layer into lists of (z,polygon) tuples according to buffer entries.
 
         Arguments (implicit):
@@ -94,6 +93,7 @@ class PolyPrism(GeometryEntity):
 
         Returns:
             buffered_polygons: list of (z, buffered_polygons)
+
         """
         all_polygons_list = []
         for polygon in polygons.geoms if hasattr(polygons, "geoms") else [polygons]:
@@ -106,7 +106,7 @@ class PolyPrism(GeometryEntity):
 
     def _create_volume_directly(
         self,
-        entry: List[Tuple[float, Polygon]],
+        entry: list[tuple[float, Polygon]],
         exterior: bool = True,
         interior_index: int = 0,
     ) -> int:
@@ -179,7 +179,7 @@ class PolyPrism(GeometryEntity):
         polygon_z: float,
         exterior: bool,
         interior_index: int,
-    ) -> List[Tuple[float, float, float]]:
+    ) -> list[tuple[float, float, float]]:
         """"""
         # Draw xy surface
         return (
@@ -191,7 +191,7 @@ class PolyPrism(GeometryEntity):
         )
 
     def _create_volume_with_holes_directly(
-        self, entry: List[Tuple[float, Polygon]]
+        self, entry: list[tuple[float, Polygon]]
     ) -> int:
         """Create volume with holes directly using GMSH calls."""
         exterior = self._create_volume_directly(entry, exterior=True)
@@ -218,7 +218,7 @@ class PolyPrism(GeometryEntity):
             self._clear_caches()
         return exterior
 
-    def _create_surfaces_with_holes_at_z(self, polygons, z) -> List[int]:
+    def _create_surfaces_with_holes_at_z(self, polygons, z) -> list[int]:
         """Create surfaces with holes at given z level directly using GMSH calls."""
         surfaces = []
         for polygon in polygons.geoms if hasattr(polygons, "geoms") else [polygons]:
@@ -304,7 +304,7 @@ class PolyPrism(GeometryEntity):
         model.occ.remove(list(prisms_dimtags))
         return subdivided_prisms
 
-    def instanciate(self, cad_model) -> List[Tuple[int, int]]:
+    def instanciate(self, cad_model) -> list[tuple[int, int]]:
         """Create GMSH volumes directly without using CAD class methods."""
         prisms = self._create_volumes_directly()
         gmsh.model.occ.synchronize()

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -2,6 +2,7 @@
 import gmsh
 from shapely.geometry import MultiPolygon, Polygon
 
+from meshwell.cad import CAD
 from meshwell.geometry_entity import GeometryEntity
 
 
@@ -81,7 +82,10 @@ class PolySurface(GeometryEntity):
 
         return exterior
 
-    def instanciate(self) -> list[tuple[int, int]]:
+    def instanciate(
+        self,
+        cad_model: CAD | None = None,  # noqa: ARG002
+    ) -> list[tuple[int, int]]:
         """Create GMSH surfaces directly without using CAD class methods."""
         surfaces = []
         for polygon in self.polygons:

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -81,7 +81,7 @@ class PolySurface(GeometryEntity):
 
         return exterior
 
-    def instantiate(self) -> list[tuple[int, int]]:
+    def instanciate(self) -> list[tuple[int, int]]:
         """Create GMSH surfaces directly without using CAD class methods."""
         surfaces = []
         for polygon in self.polygons:

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -1,3 +1,4 @@
+"""PolySurface definitions."""
 import gmsh
 from shapely.geometry import MultiPolygon, Polygon
 
@@ -80,7 +81,7 @@ class PolySurface(GeometryEntity):
 
         return exterior
 
-    def instanciate(self, cad_model) -> list[tuple[int, int]]:
+    def instantiate(self) -> list[tuple[int, int]]:
         """Create GMSH surfaces directly without using CAD class methods."""
         surfaces = []
         for polygon in self.polygons:

--- a/meshwell/polysurface.py
+++ b/meshwell/polysurface.py
@@ -1,25 +1,24 @@
-from shapely.geometry import Polygon, MultiPolygon
-from typing import List, Optional, Union, Tuple
 import gmsh
+from shapely.geometry import MultiPolygon, Polygon
 
 from meshwell.geometry_entity import GeometryEntity
 
 
 class PolySurface(GeometryEntity):
-    """
-    Creates bottom-up GMSH polygonal surfaces formed by list of shapely (multi)polygon.
+    """Creates bottom-up GMSH polygonal surfaces formed by list of shapely (multi)polygon.
 
     Attributes:
         polygons: list of shapely (Multi)Polygon
         model: GMSH model to synchronize
         physical_name: name of the physical this entity wil belong to
         mesh_order: priority of the entity if it overlaps with others (lower numbers override higher numbers)
+
     """
 
     def __init__(
         self,
-        polygons: Union[Polygon, List[Polygon], MultiPolygon, List[MultiPolygon]],
-        physical_name: Optional[str | tuple[str, ...]] = None,
+        polygons: Polygon | list[Polygon] | MultiPolygon | list[MultiPolygon],
+        physical_name: str | tuple[str, ...] | None = None,
         mesh_order: float | None = None,
         mesh_bool: bool = True,
         additive: bool = False,
@@ -81,7 +80,7 @@ class PolySurface(GeometryEntity):
 
         return exterior
 
-    def instanciate(self, cad_model) -> List[Tuple[int, int]]:
+    def instanciate(self, cad_model) -> list[tuple[int, int]]:
         """Create GMSH surfaces directly without using CAD class methods."""
         surfaces = []
         for polygon in self.polygons:

--- a/meshwell/resolution.py
+++ b/meshwell/resolution.py
@@ -61,7 +61,7 @@ class ConstantInField(ResolutionSpec):
 
     resolution: float
 
-    def apply(self, model: Any, entities_mass_dict) -> int:
+    def apply(self, model: Any, entities_mass_dict, **kwargs) -> int:  # noqa: ARG002
         """Apply constant resolution field to the model.
 
         Creates a MathEval field with constant resolution and restricts it
@@ -70,6 +70,7 @@ class ConstantInField(ResolutionSpec):
         Args:
             model: The mesh model to apply the field to.
             entities_mass_dict: Dictionary mapping entity tags to their masses.
+            **kwargs: Unused kwargs
 
         Returns:
             int: Index of the created restrict field.

--- a/meshwell/resolution.py
+++ b/meshwell/resolution.py
@@ -1,3 +1,4 @@
+"""Resolution specifications."""
 import copy
 import warnings
 from typing import Any, Literal
@@ -49,11 +50,30 @@ class ResolutionSpec(BaseModel):
 
 
 class ConstantInField(ResolutionSpec):
-    """Constant resolution within the entities."""
+    """Provides constant resolution within specified entities.
+
+    This class implements a resolution specification that applies a uniform
+    mesh size throughout the specified geometric entities.
+
+    Attributes:
+        resolution: The constant mesh resolution to apply.
+    """
 
     resolution: float
 
-    def apply(self, model: Any, entities_mass_dict, **kwargs) -> int:
+    def apply(self, model: Any, entities_mass_dict) -> int:
+        """Apply constant resolution field to the model.
+
+        Creates a MathEval field with constant resolution and restricts it
+        to the specified entities.
+
+        Args:
+            model: The mesh model to apply the field to.
+            entities_mass_dict: Dictionary mapping entity tags to their masses.
+
+        Returns:
+            int: Index of the created restrict field.
+        """
         matheval_field_index = model.mesh.field.add("MathEval")
         model.mesh.field.setString(matheval_field_index, "F", f"{self.resolution}")
         restrict_field_index = model.mesh.field.add("Restrict")
@@ -65,9 +85,18 @@ class ConstantInField(ResolutionSpec):
             self.entity_str,
             list(entities_mass_dict.keys()),
         )
+
         return restrict_field_index
 
     def refine(self, resolution_factor: float):
+        """Create a refined copy with adjusted resolution.
+
+        Args:
+            resolution_factor: Factor to multiply the resolution by.
+
+        Returns:
+            ConstantInField: A new instance with refined resolution.
+        """
         result = copy.copy(self)
         if result.resolution is not None:
             result.resolution *= resolution_factor
@@ -76,17 +105,39 @@ class ConstantInField(ResolutionSpec):
 
 
 class SampledField(ResolutionSpec):
-    """Shared functionality for size fields that require sampling the entities at points."""
+    """Base class for size fields that require sampling entities at points.
+
+    This class provides shared functionality for resolution specifications
+    that need to sample geometric entities to determine appropriate mesh sizing.
+
+    Attributes:
+        mass_per_sampling: Mass threshold per sampling point.
+            If None, defaults to 0.5 * sizemin.
+        max_sampling: Maximum number of sampling points allowed (default: 100).
+        sizemin: Minimum mesh size.
+    """
 
     mass_per_sampling: float | None = None
     max_sampling: int = 100
     sizemin: float
 
     def calculate_samplings(self, entities_mass_dict):
-        """Calculates a more optimal sampling from the masses."""
+        """Calculate optimal sampling distribution based on entity masses.
+
+        Determines the number of sampling points for each entity based on
+        its mass and the specified mass_per_sampling ratio.
+
+        Args:
+            entities_mass_dict: Dictionary mapping entity tags to their masses.
+
+        Returns:
+            dict: Mapping of entity tags to their calculated sampling counts.
+        """
         if self.mass_per_sampling is None:
             # Default sampling is half the minimum resolution
             mass_per_sampling = 0.5 * self.sizemin
+        else:
+            mass_per_sampling = self.mass_per_sampling
 
         return {
             tag: min(max(2, int(mass / mass_per_sampling)), self.max_sampling)
@@ -96,7 +147,16 @@ class SampledField(ResolutionSpec):
         }
 
     def apply_distance(self, model: Any, entities_mass_dict):
-        # Compute samplings
+        """Create and configure a distance field for the specified entities.
+
+        Args:
+            model: The mesh model to apply the field to.
+            entities_mass_dict: Dictionary mapping entity tags to their masses.
+
+        Returns:
+            int: Index of the created distance field.
+        """
+        # Compute optimal samplings for each entity
         samplings_dict = self.calculate_samplings(entities_mass_dict)
 
         # FIXME: It is computationally cheaper to have a large sampling on all the curves rather than one field per curve; but there is probably an optimum somewhere.
@@ -116,7 +176,20 @@ class SampledField(ResolutionSpec):
         restrict_to_str: str,
         restrict_to_tags=None,
     ):
-        """Common application."""
+        """Apply restriction to limit a field to specific entities.
+
+        Creates a restriction field that limits the application of another
+        field to specified geometric entities.
+
+        Args:
+            model: The mesh model to apply the restriction to.
+            target_field_index (int): Index of the field to restrict.
+            restrict_to_str (str): String identifier for the restriction type.
+            restrict_to_tags: List of entity tags to restrict to.
+
+        Returns:
+            int: Index of the created restriction field.
+        """
         restrict_field_index = model.mesh.field.add("Restrict")
         model.mesh.field.setNumber(restrict_field_index, "InField", target_field_index)
         model.mesh.field.setNumbers(
@@ -124,11 +197,22 @@ class SampledField(ResolutionSpec):
             restrict_to_str,
             restrict_to_tags,
         )
+
         return restrict_field_index
 
 
 class ThresholdField(SampledField):
-    """Linear growth of the resolution away from the entity."""
+    """Implements linear growth of resolution away from entities.
+
+    This class creates a threshold field that provides fine resolution near
+    specified entities and gradually increases the mesh size with distance.
+
+    Attributes:
+        sizemax (float): Maximum mesh size at far distances.
+        sizemin (float): Minimum mesh size near entities.
+        distmin (float): Distance where minimum size applies (default: 0).
+        distmax (float): Distance where maximum size applies.
+    """
 
     sizemax: float
     sizemin: float
@@ -142,6 +226,23 @@ class ThresholdField(SampledField):
         restrict_to_str,
         restrict_to_tags=None,
     ) -> int:
+        """Apply threshold field with linear resolution growth.
+
+        Creates a distance-based field that transitions from minimum to maximum
+        mesh size over the specified distance range.
+
+        Args:
+            model: The mesh model to apply the field to.
+            entities_mass_dict: Dictionary mapping entity tags to their masses.
+            restrict_to_str (str): String identifier for restriction type.
+            restrict_to_tags: List of entity tags to restrict the field to.
+
+        Returns:
+            int | None: Index of the created field, or None if skipped.
+
+        Warnings:
+            UserWarning: If attempting to set distance field on a Volume.
+        """
         if self.entity_str == "RegionsList":
             warnings.warn(
                 "Cannot set a distance field on a Volume! Skipping", stacklevel=2
@@ -175,7 +276,16 @@ class ThresholdField(SampledField):
         return None
 
     def refine(self, resolution_factor: float):
+        """Create a refined copy with adjusted size parameters.
+
+        Args:
+            resolution_factor (float): Factor to multiply size parameters by.
+
+        Returns:
+            ThresholdField: A new instance with refined size parameters.
+        """
         result = copy.copy(self)
+
         if result.sizemax is not None:
             result.sizemax *= resolution_factor
         if result.sizemin is not None:
@@ -185,7 +295,12 @@ class ThresholdField(SampledField):
 
 
 class ExponentialField(SampledField):
-    """Exponential growth of the characteristic length away from the entity."""
+    """Exponential growth of the characteristic length away from the entity.
+
+    Attributes:
+        growth_factor: Factor by which the mesh size grows exponentially
+        lengthscale: Characteristic length scale for the exponential growth
+    """
 
     growth_factor: float
     lengthscale: float
@@ -196,7 +311,21 @@ class ExponentialField(SampledField):
         entities_mass_dict,
         restrict_to_str,
         restrict_to_tags=None,
-    ) -> int:
+    ) -> int | None:
+        """Apply the exponential field to the mesh model.
+
+        Args:
+            model: The mesh model to apply the field to
+            entities_mass_dict: Dictionary mapping entities to their mass properties
+            restrict_to_str: String representation of restriction criteria
+            restrict_to_tags: Optional list of tags to restrict the field to
+
+        Returns:
+            int: Index of the created field, or None if field cannot be applied
+
+        Warnings:
+            UserWarning: If attempting to set distance field on a Volume
+        """
         if self.entity_str == "RegionsList":
             warnings.warn(
                 "Cannot set a distance field on a Volume! Skipping", stacklevel=2
@@ -224,6 +353,19 @@ class ExponentialField(SampledField):
         return None
 
     def refine(self, resolution_factor: float):
+        """Create a refined copy of this field with adjusted resolution.
+
+        The minimum size is scaled by the resolution factor to create a finer
+        or coarser mesh as needed.
+
+        Args:
+            resolution_factor (float): Factor to scale the minimum size by.
+                                     Values < 1.0 create finer meshes,
+                                     values > 1.0 create coarser meshes
+
+        Returns:
+            ExponentialField: A new field instance with adjusted resolution
+        """
         result = copy.copy(self)
         if result.sizemin is not None:
             result.sizemin *= resolution_factor

--- a/meshwell/tag.py
+++ b/meshwell/tag.py
@@ -1,8 +1,7 @@
-from typing import List
 from itertools import combinations, product
 
 
-def tag_entities(entity_list: List, model):
+def tag_entities(entity_list: list, model):
     """Adds physical labels to the entities in the model."""
     # One pass to get the global name --> dimtags mapping
     names_to_tags = {
@@ -18,12 +17,12 @@ def tag_entities(entity_list: List, model):
                 names_to_tags[dim][physical_name] = []
             names_to_tags[dim][physical_name].extend(entities.tags)
 
-    for dim in names_to_tags.keys():
+    for dim in names_to_tags:
         for physical_name, tags in names_to_tags[dim].items():
             model.addPhysicalGroup(dim, tags, name=physical_name)
 
 
-def tag_interfaces(entity_list: List, max_dim: int, boundary_delimiter: str, model):
+def tag_interfaces(entity_list: list, max_dim: int, boundary_delimiter: str, model):
     """Adds physical labels to the interfaces between entities in entity_list."""
     names_to_tags = {
         0: {},
@@ -31,31 +30,30 @@ def tag_interfaces(entity_list: List, max_dim: int, boundary_delimiter: str, mod
         2: {},
     }
     for entity1, entity2 in combinations(entity_list, 2):
-        if entity1.physical_name == entity2.physical_name:
+        if (
+            entity1.physical_name == entity2.physical_name
+            or entity1.dim != entity2.dim
+            or entity1.dim != max_dim
+        ):
             continue
-        elif entity1.dim != entity2.dim:
-            continue
-        elif entity1.dim != max_dim:  # ignore lower-dimensional entities
-            continue
-        else:
-            dim = entity1.dim - 1
-            common_interfaces = list(
-                set(entity1.boundaries).intersection(entity2.boundaries)
-            )
-            if common_interfaces:
-                # Update entity interface logs
-                entity1.interfaces.extend(common_interfaces)
-                entity2.interfaces.extend(common_interfaces)
-                # Prepare physical tags
-                for entity1_physical_name, entity2_physical_name in product(
-                    entity1.physical_name, entity2.physical_name
-                ):
-                    interface_name = f"{entity1_physical_name}{boundary_delimiter}{entity2_physical_name}"
-                    if interface_name not in names_to_tags[dim]:
-                        names_to_tags[dim][interface_name] = []
-                    names_to_tags[dim][interface_name].extend(common_interfaces)
+        dim = entity1.dim - 1
+        common_interfaces = list(
+            set(entity1.boundaries).intersection(entity2.boundaries)
+        )
+        if common_interfaces:
+            # Update entity interface logs
+            entity1.interfaces.extend(common_interfaces)
+            entity2.interfaces.extend(common_interfaces)
+            # Prepare physical tags
+            for entity1_physical_name, entity2_physical_name in product(
+                entity1.physical_name, entity2.physical_name
+            ):
+                interface_name = f"{entity1_physical_name}{boundary_delimiter}{entity2_physical_name}"
+                if interface_name not in names_to_tags[dim]:
+                    names_to_tags[dim][interface_name] = []
+                names_to_tags[dim][interface_name].extend(common_interfaces)
 
-    for dim in names_to_tags.keys():
+    for dim in names_to_tags:
         for physical_name, tags in names_to_tags[dim].items():
             model.addPhysicalGroup(dim, tags, name=physical_name)
 
@@ -63,7 +61,7 @@ def tag_interfaces(entity_list: List, max_dim: int, boundary_delimiter: str, mod
 
 
 def tag_boundaries(
-    entity_list: List, max_dim: int, boundary_delimiter: str, mesh_edge_name: str, model
+    entity_list: list, max_dim: int, boundary_delimiter: str, mesh_edge_name: str, model
 ):
     """Adds physical labels to the boundaries of the entities in entity_list."""
     names_to_tags = {
@@ -85,6 +83,6 @@ def tag_boundaries(
                 names_to_tags[dim][boundary_name] = []
             names_to_tags[dim][boundary_name].extend(boundaries)
 
-    for dim in names_to_tags.keys():
+    for dim in names_to_tags:
         for physical_name, tags in names_to_tags[dim].items():
             model.addPhysicalGroup(dim, tags, name=physical_name)

--- a/meshwell/tag.py
+++ b/meshwell/tag.py
@@ -1,3 +1,4 @@
+"""Mesh tagging utilities."""
 from itertools import combinations, product
 
 

--- a/meshwell/utils.py
+++ b/meshwell/utils.py
@@ -1,5 +1,6 @@
 from difflib import unified_diff
 from pathlib import Path
+
 from meshwell.config import PATH
 
 
@@ -16,7 +17,7 @@ def compare_gmsh_files(meshfile: Path, other_meshfile: Path | None = None):
         actual_lines = f.readlines()
 
     diff = list(unified_diff(expected_lines, actual_lines))
-    assert diff == [], f"Mesh {str(meshfile)} differs from its reference!"
+    assert diff == [], f"Mesh {meshfile!s} differs from its reference!"
 
 
 def compare_mesh_headers(meshfile: Path, other_meshfile: Path | None = None):
@@ -45,4 +46,4 @@ def compare_mesh_headers(meshfile: Path, other_meshfile: Path | None = None):
                 break
 
     diff = list(unified_diff(expected_lines, actual_lines))
-    assert diff == [], f"Mesh headers in {str(meshfile)} differ from reference!"
+    assert diff == [], f"Mesh headers in {meshfile!s} differ from reference!"

--- a/meshwell/utils.py
+++ b/meshwell/utils.py
@@ -1,33 +1,52 @@
+"""Mesh comparison utilities."""
 from difflib import unified_diff
 from pathlib import Path
 
 from meshwell.config import PATH
 
 
-def compare_gmsh_files(meshfile: Path, other_meshfile: Path | None = None):
+def compare_gmsh_files(meshfile: Path, other_meshfile: Path | None = None) -> None:
+    """Compare two GMSH mesh files and assert they are identical.
+
+    Args:
+        meshfile: Path to the mesh file to compare
+        other_meshfile: Optional path to compare against. If None, uses reference file
+                       from PATH.references directory
+
+    Raises:
+        AssertionError: If the files differ
+    """
     meshfile2 = meshfile
     if other_meshfile is None:
         meshfile1 = PATH.references / str(meshfile)
     else:
         meshfile1 = other_meshfile
 
-    with open(str(meshfile1)) as f:
+    with meshfile1.open() as f:
         expected_lines = f.readlines()
-    with open(str(meshfile2)) as f:
+    with meshfile2.open() as f:
         actual_lines = f.readlines()
 
     diff = list(unified_diff(expected_lines, actual_lines))
-    assert diff == [], f"Mesh {meshfile!s} differs from its reference!"
+    if diff != []:
+        raise ValueError(f"Mesh {meshfile!s} differs from its reference!")
 
 
-def compare_mesh_headers(meshfile: Path, other_meshfile: Path | None = None):
+def compare_mesh_headers(meshfile: Path, other_meshfile: Path | None = None) -> None:
+    """Compare mesh file headers.
+
+    Args:
+        meshfile: Path to the mesh file whose header to compare
+        other_meshfile: Optional path to compare against. If None, uses reference file
+                       with .reference.msh extension from PATH.references directory
+    """
     meshfile2 = meshfile
     if other_meshfile is None:
         meshfile1 = PATH.references / (str(meshfile.with_suffix("")) + ".reference.msh")
     else:
         meshfile1 = other_meshfile
 
-    with open(str(meshfile1)) as f:
+    with meshfile1.open() as f:
         expected_lines = []
         for line in f:
             expected_lines.append(line)
@@ -36,7 +55,7 @@ def compare_mesh_headers(meshfile: Path, other_meshfile: Path | None = None):
                 expected_lines.append(next(f))
                 break
 
-    with open(str(meshfile2)) as f:
+    with meshfile2.open() as f:
         actual_lines = []
         for line in f:
             actual_lines.append(line)
@@ -46,4 +65,5 @@ def compare_mesh_headers(meshfile: Path, other_meshfile: Path | None = None):
                 break
 
     diff = list(unified_diff(expected_lines, actual_lines))
-    assert diff == [], f"Mesh headers in {meshfile!s} differ from reference!"
+    if diff != []:
+        raise ValueError(f"Mesh headers in {meshfile!s} differ from reference!")

--- a/meshwell/validation.py
+++ b/meshwell/validation.py
@@ -1,9 +1,21 @@
+"""Mesh validation routines."""
 import math
 
 from meshwell.labeledentity import LabeledEntities
 
 
 def validate_dimtags(dimtags):
+    """Validate that all dimension-tag pairs have the same dimension.
+
+    Args:
+        dimtags: List of (dimension, tag) tuples representing geometric entities
+
+    Returns:
+        int: The common dimension of all entities
+
+    Raises:
+        ValueError: If entities have different dimensions
+    """
     dims = [dim for dim, tag in dimtags]
     if len(set(dims)) != 1:
         raise ValueError(
@@ -12,14 +24,32 @@ def validate_dimtags(dimtags):
     return dims[0]
 
 
-def format_physical_name(physical_name: str):
-    # Format physical name
+def format_physical_name(physical_name: str | tuple[str, ...]) -> tuple[str, ...]:
+    """Format a physical name to ensure consistent tuple representation.
+
+    Args:
+        physical_name: The physical name to format
+
+    Returns:
+        tuple: A tuple containing the physical name
+    """
     if isinstance(physical_name, str):
         return (physical_name,)
     return physical_name
 
 
 def unpack_dimtags(dimtags):
+    """Unpack and flatten dimension-tag pairs into a consistent format.
+
+    Takes a list of (dimension, tag) pairs and ensures all tags are at the same
+    level, flattening any nested lists of tags while preserving the dimension.
+
+    Args:
+        dimtags: List of (dimension, tag) tuples, where tags may be nested lists
+
+    Returns:
+        list: List of (dimension, tag) tuples with flattened tags
+    """
     dim = next(dim for dim, tag in dimtags)
     tags = [tag for dim, tag in dimtags]
     if any(isinstance(el, list) for el in tags):
@@ -61,7 +91,6 @@ def order_entities(entities):
 
 def consolidate_entities_by_physical_name(entities):
     """Returns a new list of LabeledEntities, with a single entity per physical_name."""
-    consolidated_entities = []
     physical_name_dict = {}
 
     for entity in entities:
@@ -80,7 +109,4 @@ def consolidate_entities_by_physical_name(entities):
             )
             physical_name_dict[entity.physical_name] = combined_entity
 
-    for entity in physical_name_dict.values():
-        consolidated_entities.append(entity)
-
-    return consolidated_entities
+    return list(physical_name_dict.values())

--- a/meshwell/validation.py
+++ b/meshwell/validation.py
@@ -1,5 +1,6 @@
-from meshwell.labeledentity import LabeledEntities
 import math
+
+from meshwell.labeledentity import LabeledEntities
 
 
 def validate_dimtags(dimtags):
@@ -8,20 +9,18 @@ def validate_dimtags(dimtags):
         raise ValueError(
             "All the entities corresponding to a mesh physical_name must be of the same dimension."
         )
-    else:
-        return dims[0]
+    return dims[0]
 
 
 def format_physical_name(physical_name: str):
     # Format physical name
     if isinstance(physical_name, str):
         return (physical_name,)
-    else:
-        return physical_name
+    return physical_name
 
 
 def unpack_dimtags(dimtags):
-    dim = [dim for dim, tag in dimtags][0]
+    dim = next(dim for dim, tag in dimtags)
     tags = [tag for dim, tag in dimtags]
     if any(isinstance(el, list) for el in tags):
         tags = [item for sublist in tags for item in sublist]

--- a/meshwell/visualization.py
+++ b/meshwell/visualization.py
@@ -37,7 +37,7 @@ def plot2D(
     ignore_lines: bool = False,
 ):
     # Create matplotlib figure
-    fig, ax = plt.subplots(figsize=(10, 10))
+    _fig, ax = plt.subplots(figsize=(10, 10))
 
     # Create mapping dicts from integer IDs to group names
     id_to_name = {}

--- a/meshwell/visualization.py
+++ b/meshwell/visualization.py
@@ -1,3 +1,4 @@
+"""Plotting routines."""
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -35,8 +36,17 @@ def plot2D(
     wireframe: bool = False,
     title: str | None = None,
     ignore_lines: bool = False,
-):
-    # Create matplotlib figure
+) -> None:
+    """Plot a 2D mesh using matplotlib.
+
+    Args:
+        mesh: The mesh object to be plotted
+        physicals: Physical regions to highlight
+        wireframe: Whether to display mesh as wireframe
+        title: Plot title
+        ignore_lines: Whether to ignore line elements in the mesh
+    """
+    # Create matplotlib figure with specified dimensions
     _fig, ax = plt.subplots(figsize=(10, 10))
 
     # Create mapping dicts from integer IDs to group names
@@ -68,9 +78,12 @@ def plot2D(
     # Plot triangles for each 2D physical group
     for i, group in enumerate(physical_groups_2D):
         # Skip if physicals specified and this group not in them
-        if physicals is not None and "gmsh:physical" in mesh.cell_data_dict:
-            if not any(name in physicals for name in id_to_name[group]):
-                continue
+        if (
+            physicals is not None
+            and "gmsh:physical" in mesh.cell_data_dict
+            and not any(name in physicals for name in id_to_name[group])
+        ):
+            continue
 
         # Get cells for this physical group
         if (
@@ -117,9 +130,12 @@ def plot2D(
     if not ignore_lines:
         for i, group in enumerate(physical_groups_1D):
             # Skip if physicals specified and this group not in them
-            if physicals is not None and "gmsh:physical" in mesh.cell_data_dict:
-                if not any(name in physicals for name in id_to_name[group]):
-                    continue
+            if (
+                physicals is not None
+                and "gmsh:physical" in mesh.cell_data_dict
+                and not any(name in physicals for name in id_to_name[group])
+            ):
+                continue
 
             # Get cells for this physical group
             if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ ignore = [
   "C901", # too complex
   "B905", # `zip()` without an explicit `strict=` parameter
   "C408", # C408 Unnecessary `dict` call (rewrite as a literal)
+  "D107", # docstrings for __init__
 ]
 select = [
   "E",    # pycodestyle errors
@@ -158,8 +159,17 @@ select = [
   "RUF",  # ruff
 ]
 
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
 [tool.ruff.lint.per-file-ignores]
-"docs/*.py" = ["B018"] # allow useless expressions for notebooks
+"docs/*.py" = [
+    "B018", # allow useless expressions for notebooks
+    "D100",
+    "D103"
+]
+"tests/**/*.py" = ["S101", "D100", "D102", "D103"]
 
 [tool.setuptools.package-data]
 mypkg = ["*.csv", "*.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,61 +1,44 @@
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+
 [build-system]
-requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
+requires = ["flit_core >=3.2,<4"]
 
 [project]
-name="meshwell"
-description="GMSH wrapper, with integrated photonics focus"
+authors = [{ name = "Simon Bilodeau", email = "sb30@princeton.edu" }]
 classifiers = [
-	"Programming Language :: Python :: 3.11",
-	"Programming Language :: Python :: 3.12",
-	"Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Operating System :: OS Independent",
 ]
-version="2.1.0"
-authors = [
-    {name = "Simon Bilodeau", email = "sb30@princeton.edu"},
-]
+dependencies = ["shapely", "gmsh", "meshio", "tqdm", "pydantic", "gdstk"]
+description = "GMSH wrapper, with integrated photonics focus"
 keywords = ["python"]
-license = {file = "LICENSE"}
-dependencies = [
-    "shapely",
-    "gmsh",
-    "meshio",
-    "tqdm",
-    "pydantic",
-    "gdstk"
-]
+license = { file = "LICENSE" }
+name = "meshwell"
 readme = "README.md"
 requires-python = ">=3.11"
+version = "2.1.0"
 
 [project.optional-dependencies]
 dev = [
-    "pre-commit",
-    "pytest",
-    "pytest-xdist",
-    "pytest-cov",
-    "pytest_regressions",
-    "jupytext",
-    "autodoc_pydantic",
-    "jupytext",
-    "jupyter-book==1.0.4.post1",
-    "sphinx-autodoc-typehints",
-    "sphinx-click",
-    "myst-parser",
-    "plotly",
-    "matplotlib"
-    ]
-
-[tool.setuptools.packages]
-find = {}
-
-# [project.scripts]
-# meshwell = "meshwell.cli:cli"
+  "pre-commit",
+  "pytest",
+  "pytest-xdist",
+  "pytest-cov",
+  "pytest_regressions",
+  "jupytext",
+  "autodoc_pydantic",
+  "jupytext",
+  "jupyter-book==1.0.4.post1",
+  "sphinx-autodoc-typehints",
+  "sphinx-click",
+  "myst-parser",
+  "plotly",
+  "matplotlib",
+]
 
 [tool.black]
-line-length = 88
-target-version = ['py310']
-include = '\.pyi?$'
 exclude = '''  # Specify the files/dirs that should be ignored by the black formatter
 /(
     \.eggs
@@ -71,82 +54,115 @@ exclude = '''  # Specify the files/dirs that should be ignored by the black form
   | dist
 )/
 '''
-
-[tool.pytest.ini_options]
-testpaths = ["meshwell/", "tests"]
-# addopts = --tb=no
-addopts = '--tb=short'
-python_files = ["meshwell/*.py", "notebooks/*.ipynb", "tests/*.py"]
-norecursedirs = ["extra/*.py"]
-
-[tool.flake8]
-max-line-length = 88
-max-complexity = 57
-select = ["B","C","E","F","W","T4","B9"]
-ignore = [ "E501", "E503", "E722", "W503", "W503", "E203", "B950", "B305", "B018", "B902", "B020", "B905"]
-extend-ignore = "RST303"
-
-exclude = [
-    ".git",
-    "__pycache__",
-    "lib",
-    "docs/source/conf.py",
-    "build",
-    "dist",
-    ".ipynb_checkpoints",
-    ".tox",
-    "extra",
-    "deprecated",
-    ".mypy_cache",
-    "venv",
-    ]
+include = '\.pyi?$'
+line-length = 88
+target-version = ['py310']
 
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "0.1.0"
-version_files = [
-    "pyproject.toml:version",
+version_files = ["pyproject.toml:version"]
+
+[tool.flake8]
+exclude = [
+  ".git",
+  "__pycache__",
+  "lib",
+  "docs/source/conf.py",
+  "build",
+  "dist",
+  ".ipynb_checkpoints",
+  ".tox",
+  "extra",
+  "deprecated",
+  ".mypy_cache",
+  "venv",
 ]
+extend-ignore = "RST303"
+ignore = [
+  "E501",
+  "E503",
+  "E722",
+  "W503",
+  "W503",
+  "E203",
+  "B950",
+  "B305",
+  "B018",
+  "B902",
+  "B020",
+  "B905",
+]
+max-complexity = 57
+max-line-length = 88
+select = ["B", "C", "E", "F", "W", "T4", "B9"]
+
+[tool.isort]
+include_trailing_comma = true
+line_length = 88
+multi_line_output = 3
 
 [tool.mypy]
 python_version = "3.10"
 strict = true
+
+[tool.pydocstyle]
+add-ignore = ["D100", "D101", "D102", "D103", "D104", "D203", "D405", "D417"]
+convention = "google"
+inherit = false
+match = "(?!test).*\\.py"
 
 [tool.pylsp-mypy]
 enabled = true
 live_mode = true
 strict = true
 
-[tool.isort]
-multi_line_output = 3
-line_length = 88
-include_trailing_comma = true
-# skip = "meshwell/__init__.py"
+[tool.pytest.ini_options]
+# addopts = --tb=no
+addopts = '--tb=short'
+norecursedirs = ["extra/*.py"]
+python_files = ["meshwell/*.py", "notebooks/*.ipynb", "tests/*.py"]
+testpaths = ["meshwell/", "tests"]
+
+[tool.ruff.lint]
+ignore = [
+  "E501", # line too long, handled by black
+  "B008", # do not perform function calls in argument defaults
+  "C901", # too complex
+  "B905", # `zip()` without an explicit `strict=` parameter
+  "C408", # C408 Unnecessary `dict` call (rewrite as a literal)
+]
+select = [
+  "E",    # pycodestyle errors
+  "W",    # pycodestyle warnings
+  "F",    # pyflakes
+  "I",    # isort
+  "C",    # flake8-comprehensions
+  "B",    # flake8-bugbear
+  "D",    # pydocstyle
+  "UP",   # pyupgrade
+  "T10",  # flake8-debugger
+  "S",    # flake8-bandit
+  "PT",   # flake8-pytest-style
+  "SIM",  # flake8-simplify
+  "RET",  # flake8-return
+  "RSE",  # flake8-raise
+  "Q",    # flake8-quotes
+  "SLOT", # flake8-slots
+  "ARG",  # flake8-unused-arguments
+  "PTH",  # flake8-use-pathlib
+  "PD",   # pandas-vet
+  "FLY",  # flynt
+  "NPY",  # numpy
+  "PERF", # perflint
+  "RUF",  # ruff
+]
+
+[tool.ruff.lint.per-file-ignores]
+"docs/*.py" = ["B018"] # allow useless expressions for notebooks
 
 [tool.setuptools.package-data]
 mypkg = ["*.csv", "*.yaml"]
 
-[tool.pydocstyle]
-inherit = false
-match = "(?!test).*\\.py"
-add-ignore = ["D100","D101","D102","D103","D104","D203","D405","D417"]
-convention = "google"
-
-[tool.ruff.lint]
-select = [
-    "E",  # pycodestyle errors
-    "W",  # pycodestyle warnings
-    "F",  # pyflakes
-    # "I",  # isort
-    "C",  # flake8-comprehensions
-    "B",  # flake8-bugbear
-]
-ignore = [
-    "E501",  # line too long, handled by black
-    "B008",  # do not perform function calls in argument defaults
-    "C901",  # too complex
-    "B905",  # `zip()` without an explicit `strict=` parameter
-    "C408",  # C408 Unnecessary `dict` call (rewrite as a literal)
-]
-[tool.ruff.lint.per-file-ignores]
-"docs/*.py" = ["B018"] # allow useless expressions for notebooks
+[tool.setuptools.packages]
+find = {}

--- a/tests/generate_references.py
+++ b/tests/generate_references.py
@@ -1,22 +1,28 @@
-import os
-import pytest
-from meshwell.config import PATH
 import argparse
-import sys
+import os
 import pathlib
+import sys
+
+import pytest
+
+from meshwell.config import PATH
 
 if __name__ == "__main__":
-
     # Set up argument parser
-    parser = argparse.ArgumentParser(description='Generate reference files for tests')
-    parser.add_argument('--references-path', type=str, help='Path to references directory', default=PATH.references)
+    parser = argparse.ArgumentParser(description="Generate reference files for tests")
+    parser.add_argument(
+        "--references-path",
+        type=str,
+        help="Path to references directory",
+        default=PATH.references,
+    )
     args, remaining_argv = parser.parse_known_args()
 
     # Override PATH.references with command line argument if provided
     PATH.references = pathlib.Path(args.references_path)
 
     # Remove custom arguments from sys.argv
-    sys.argv = [sys.argv[0]] + remaining_argv
+    sys.argv = [sys.argv[0], *remaining_argv]
 
     # Delete existing references
     exec_dir_name = "./"

--- a/tests/test_buffers_prism.py
+++ b/tests/test_buffers_prism.py
@@ -18,7 +18,7 @@ def test_prism_value_error():
     # Buffers that will cause a change in the topology of the polygon
     buffers = {0: 0, -1: 0, -1.001: 15, -5: 0}
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         PolyPrism(polygons=polygons, buffers=buffers)
 
 

--- a/tests/test_buffers_prism.py
+++ b/tests/test_buffers_prism.py
@@ -1,5 +1,6 @@
 import pytest
 from shapely.geometry import Point
+
 from meshwell.polyprism import PolyPrism
 
 

--- a/tests/test_cad.py
+++ b/tests/test_cad.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from functools import partial
+
 import gmsh
 import shapely
-from meshwell.polyprism import PolyPrism
-from meshwell.cad import cad
 
+from meshwell.cad import cad
 from meshwell.gmsh_entity import GMSH_entity
-from functools import partial
+from meshwell.polyprism import PolyPrism
 
 
 def test_composite_cad_3D():

--- a/tests/test_from_gds.py
+++ b/tests/test_from_gds.py
@@ -1,6 +1,8 @@
-import gdstk
 from pathlib import Path
+
+import gdstk
 import shapely.geometry as sg
+
 from meshwell.import_gds import read_gds_layers
 
 
@@ -83,7 +85,7 @@ def test_gds_to_shapely():
         # Layer 2 should have a polygon with a hole
         layer2_poly = layer_polygons[(2, 0)]
         if isinstance(layer2_poly, sg.MultiPolygon):
-            polygon = list(layer2_poly.geoms)[0]
+            polygon = next(iter(layer2_poly.geoms))
         else:
             polygon = layer2_poly
         assert len(polygon.interiors) > 0

--- a/tests/test_gmsh_entity.py
+++ b/tests/test_gmsh_entity.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
-import gmsh
-from meshwell.gmsh_entity import GMSH_entity
-from meshwell.cad import cad
+
 from functools import partial
+
+import gmsh
+
+from meshwell.cad import cad
+from meshwell.gmsh_entity import GMSH_entity
 
 
 def test_gmsh_entity():
@@ -20,7 +23,6 @@ def test_gmsh_entity():
 def test_custom_partial():
     def front_face_rectangle(x_min, x_max, y, z_min, z_max):
         """Assumes model is already initialized."""
-
         # Define the four corners of the rectangle in 3D space
         # Front face is at y=y_max, spanning x and z
         p1 = gmsh.model.occ.addPoint(x_min, y, z_min)
@@ -36,9 +38,7 @@ def test_custom_partial():
 
         # Create a curve loop and plane surface
         loop = gmsh.model.occ.addCurveLoop([l1, l2, l3, l4])
-        surface = gmsh.model.occ.addPlaneSurface([loop])
-
-        return surface
+        return gmsh.model.occ.addPlaneSurface([loop])
 
     gmsh_obj = GMSH_entity(
         gmsh_partial_function=partial(

--- a/tests/test_mesh_order.py
+++ b/tests/test_mesh_order.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shapely
+
 from meshwell.polysurface import PolySurface
 from meshwell.validation import order_entities
 

--- a/tests/test_multidimensional_cad.py
+++ b/tests/test_multidimensional_cad.py
@@ -1,5 +1,4 @@
-"""
-Test multi-dimensional entity processing capabilities.
+"""Test multi-dimensional entity processing capabilities.
 
 This test module validates the ability to process entities of different
 dimensions (3D volumes, 2D surfaces, 1D curves, 0D points) in a single model
@@ -8,8 +7,10 @@ using fragment-based integration.
 
 from __future__ import annotations
 
-import gmsh
 from functools import partial
+
+import gmsh
+
 from meshwell.cad import cad
 from meshwell.gmsh_entity import GMSH_entity
 from meshwell.mesh import mesh
@@ -18,7 +19,6 @@ from meshwell.resolution import ConstantInField
 
 def test_volume_with_internal_surface():
     """Test 3D volume with 2D surface fragment integration."""
-
     # Create a 3D box (volume)
     box_obj = GMSH_entity(
         gmsh_partial_function=partial(
@@ -65,7 +65,6 @@ def test_volume_with_internal_surface():
 
 def test_lower_dim_with_multiple_higher_entities():
     """Test lower-dimension object interacting with multiple higher-level entities."""
-
     # Create two 3D boxes that don't overlap
     box1_obj = GMSH_entity(
         gmsh_partial_function=partial(
@@ -129,7 +128,6 @@ def test_lower_dim_with_multiple_higher_entities():
 
 def test_surface_boundary_overlap():
     """Test surface that lies exactly on boundary of volume."""
-
     # Create a 3D box
     box_obj = GMSH_entity(
         gmsh_partial_function=partial(
@@ -175,7 +173,6 @@ def test_surface_boundary_overlap():
 
 def test_point_in_multiple_entities():
     """Test 0D point inside multiple overlapping entities."""
-
     # Create overlapping 3D entities
     box_obj = GMSH_entity(
         gmsh_partial_function=partial(
@@ -245,7 +242,6 @@ def test_point_in_multiple_entities():
 
 def test_sequential_fragmentation_complex():
     """Test sequential fragmentation with multiple lower-dim entities."""
-
     # Base 3D volume
     base_volume = GMSH_entity(
         gmsh_partial_function=partial(

--- a/tests/test_multiple_physicals.py
+++ b/tests/test_multiple_physicals.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import shapely
-from meshwell.polyprism import PolyPrism
+
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polyprism import PolyPrism
 
 
 def test_multiple_physicals():

--- a/tests/test_polyline.py
+++ b/tests/test_polyline.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import shapely
-from meshwell.polyline import PolyLine
-from meshwell.polysurface import PolySurface
+
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polyline import PolyLine
+from meshwell.polysurface import PolySurface
 from meshwell.utils import compare_gmsh_files
-from pathlib import Path
 
 
 def test_polyline_basic():

--- a/tests/test_polysurface.py
+++ b/tests/test_polysurface.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import shapely
-from meshwell.polysurface import PolySurface
+
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polysurface import PolySurface
 from meshwell.utils import compare_gmsh_files
-from pathlib import Path
 
 
 def test_polysurface():

--- a/tests/test_prism.py
+++ b/tests/test_prism.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import gmsh
-import shapely
-from meshwell.polyprism import PolyPrism
-from meshwell.cad import cad, CAD
 import numpy as np
+import shapely
+
+from meshwell.cad import CAD, cad
+from meshwell.polyprism import PolyPrism
 
 
 def test_prism():

--- a/tests/test_resolution.py
+++ b/tests/test_resolution.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
-import shapely
-from meshwell.polysurface import PolySurface
-from meshwell.polyprism import PolyPrism
-from meshwell.resolution import ConstantInField, ThresholdField, ExponentialField
-from meshwell.utils import compare_gmsh_files
 from pathlib import Path
-import pytest
+
 import numpy as np
+import pytest
+import shapely
+
 from meshwell.cad import cad
 from meshwell.mesh import mesh
+from meshwell.polyprism import PolyPrism
+from meshwell.polysurface import PolySurface
+from meshwell.resolution import ConstantInField, ExponentialField, ThresholdField
+from meshwell.utils import compare_gmsh_files
 
 
 def test_2D_resolution():
@@ -335,12 +337,12 @@ def test_filter(apply_to, min_mass, max_mass):
 
 
 @pytest.mark.parametrize(
-    ("restrict_to",),
+    "restrict_to",
     [
-        (None,),
-        (["inner_left"],),
-        (["inner_right"],),
-        (["outer", "inner_right"],),
+        None,
+        ["inner_left"],
+        ["inner_right"],
+        ["outer", "inner_right"],
     ],
 )
 def test_restrict(restrict_to):
@@ -366,10 +368,7 @@ def test_restrict(restrict_to):
         physical_name="outer",
     )
 
-    if restrict_to is None:
-        restrict_to = None
-    else:
-        restrict_to = restrict_to
+    restrict_to = None if restrict_to is None else restrict_to
     poly_left = PolySurface(
         polygons=shapely.affinity.translate(polygon2, xoff=-3.1),
         mesh_order=1,

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from pathlib import Path
-import shapely
-import gmsh
 from functools import partial
-from meshwell.polyprism import PolyPrism
-from meshwell.gmsh_entity import GMSH_entity
-from meshwell.resolution import ConstantInField
-from meshwell.cad import cad
-from meshwell.mesh import mesh
+from pathlib import Path
 
+import gmsh
+import shapely
+
+from meshwell.cad import cad
+from meshwell.gmsh_entity import GMSH_entity
+from meshwell.mesh import mesh
+from meshwell.polyprism import PolyPrism
+from meshwell.resolution import ConstantInField
 from meshwell.utils import compare_gmsh_files
 
 


### PR DESCRIPTION
This is a continuation to #135, enabling more ruff checks. Autofixes are applied and docstrings written to missing public methods.

### Commits
- **Fix trailing-whitespace check warning**
- **Update ruff pre-commit to official one**
- **Consider new ruff rules**
- **Disable ruff-format**
- **Ignore ruff code for docs notebooks**
- **Enable more ruff checks**
- **Autofix ruff checks**
- **Add missing docstrings**
