### PR TITLE
Simplify CI tests definition

### DIFF
--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 
 jobs:
 
@@ -20,25 +20,18 @@ jobs:
           python-version-file: 'pyproject.toml'
       - uses: pre-commit/action@v3.0.1
 
-
   run_regressions:
     name: Test code
     needs: pre-commit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-    - name: Set up Python 3.12
-      run: uv python install 3.12
-    - name: Generate references from reference version
-      run: bash generate_references.sh
-      working-directory: tests
-    - name: Install venv
-      run: uv venv
-    - name: Install dependencies
-      run: |
-        sudo apt-get install libglu1-mesa
-        uv pip install -e ".[dev]"
-    - name: Test
-      run: uv run pytest -n auto
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Generate references from reference version
+        run: bash generate_references.sh
+        working-directory: tests
+      - name: Install dependencies
+        run: sudo apt-get install libglu1-mesa
+      - name: Test
+        run: uv run --extra dev pytest -n auto


### PR DESCRIPTION
- **Prefer pyproject.toml python versions over hardcoded in CI**
- **Simplify uv related steps in CI tests**
  `uv run` checks pyproject.toml for a python version, creates a venv, and install deps. automatically.
